### PR TITLE
Run go staticcheck & removing reported warnings

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,7 +38,9 @@ func main() {
 		},
 	}
 
-	rand.Seed(time.Now().UnixNano())
+	// rand.Seed(time.Now().UnixNano()) // rand.Seed has been deprecated
+	randSeed := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randSeed.Uint64()
 
 	if err := app.Run(os.Args); err != nil {
 		logger.MainLog.Errorf("UPF Cli Run Error: %v", err)

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -1,8 +1,8 @@
 package factory
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
@@ -18,7 +18,7 @@ func InitConfigFactory(f string, cfg *Config) error {
 		f = UpfDefaultConfigPath
 	}
 
-	if content, err := ioutil.ReadFile(f); err != nil {
+	if content, err := os.ReadFile(f); err != nil {
 		return errors.Errorf("[Factory] %+v", err)
 	} else {
 		logger.CfgLog.Infof("Read config from [%s]", f)


### PR DESCRIPTION
Running go [staticcheck](https://staticcheck.io/docs/) & removed reported warnings.
Used below staticcheck.conf file as the staticcheck configuration file:

```
checks = ["all", "-ST1005", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023"]
initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
dot_import_whitelist = ["github.com/mmcloughlin/avo/build", "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg", "github.com/free5gc/openapi/models"]
http_status_code_whitelist = ["200", "400", "404", "500"]
```