### PR TITLE
fix: flow description should accept token "assigned"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/davecgh/go-spew v1.1.1
 	github.com/free5gc/go-gtp5gnl v1.4.6-0.20230629034810-9a49c0a5ee2f
-	github.com/free5gc/util v1.0.5-0.20230823103219-e511c4fd20ef
+	github.com/free5gc/util v1.0.5-0.20231012123940-85f4557167be
 	github.com/hashicorp/go-version v1.6.0
 	github.com/khirono/go-genl v1.0.1
 	github.com/khirono/go-nl v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/free5gc/go-gtp5gnl v1.4.6-0.20230629034810-9a49c0a5ee2f h1:+D0L2ixhbg6Iy/oQEAJQLmOU/w1mmndqVF78GdjX1yo=
 github.com/free5gc/go-gtp5gnl v1.4.6-0.20230629034810-9a49c0a5ee2f/go.mod h1:TT5aXB90NuSPMehuIK9lV2yJFnq6Qjw37ZqNB1QAKh0=
-github.com/free5gc/util v1.0.5-0.20230823103219-e511c4fd20ef h1:ne0EMnst7wbLoaY2Uvn/2Kvp/KkXKMQJcaIJQKFe+a4=
-github.com/free5gc/util v1.0.5-0.20230823103219-e511c4fd20ef/go.mod h1:l2Jrml4vojDomW5jdDJhIS60KdbrE9uPYhyAq/7OnF4=
+github.com/free5gc/util v1.0.5-0.20231012123940-85f4557167be h1:SglM1KIL+bR50hPzbvxVwNW44+yHR2tq9nTpLra75UE=
+github.com/free5gc/util v1.0.5-0.20231012123940-85f4557167be/go.mod h1:d+79g84a3YHhzvjJ2IhurrBOavOA8xWIQ/GCywPXqQk=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/internal/forwarder/flowdesc.go
+++ b/internal/forwarder/flowdesc.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-
-	"github.com/wmnsk/go-pfcp/ie"
 )
 
 // IPFilterRule <- action s dir s proto s 'from' s src 'to' s dst
@@ -33,7 +31,7 @@ type FlowDesc struct {
 	DstPorts [][]uint16
 }
 
-func ParseFlowDesc(s string, sourceInterface uint8) (*FlowDesc, error) {
+func ParseFlowDesc(s string) (*FlowDesc, error) {
 	fd := new(FlowDesc)
 	token := strings.Fields(s)
 	pos := 0
@@ -125,11 +123,6 @@ func ParseFlowDesc(s string, sourceInterface uint8) (*FlowDesc, error) {
 		if err == nil {
 			fd.DstPorts = dports
 		}
-	}
-
-	if sourceInterface == ie.SrcInterfaceAccess { // TS 29.244 5.2.1A.2A
-		fd.Dst, fd.Src = fd.Src, fd.Dst
-		fd.DstPorts, fd.SrcPorts = fd.SrcPorts, fd.DstPorts
 	}
 
 	return fd, nil

--- a/internal/forwarder/flowdesc.go
+++ b/internal/forwarder/flowdesc.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/wmnsk/go-pfcp/ie"
 )
 
 // IPFilterRule <- action s dir s proto s 'from' s src 'to' s dst
@@ -31,7 +33,7 @@ type FlowDesc struct {
 	DstPorts [][]uint16
 }
 
-func ParseFlowDesc(s string) (*FlowDesc, error) {
+func ParseFlowDesc(s string, sourceInterface uint8) (*FlowDesc, error) {
 	fd := new(FlowDesc)
 	token := strings.Fields(s)
 	pos := 0
@@ -123,6 +125,11 @@ func ParseFlowDesc(s string) (*FlowDesc, error) {
 		if err == nil {
 			fd.DstPorts = dports
 		}
+	}
+
+	if sourceInterface == ie.SrcInterfaceAccess { // TS 29.244 5.2.1A.2A
+		fd.Dst, fd.Src = fd.Src, fd.Dst
+		fd.DstPorts, fd.SrcPorts = fd.SrcPorts, fd.DstPorts
 	}
 
 	return fd, nil

--- a/internal/forwarder/flowdesc.go
+++ b/internal/forwarder/flowdesc.go
@@ -129,7 +129,7 @@ func ParseFlowDesc(s string) (*FlowDesc, error) {
 }
 
 func ParseFlowDescIPNet(s string) (*net.IPNet, error) {
-	if s == "any" {
+	if s == "any" || s == "assigned" {
 		return &net.IPNet{
 			IP:   net.IPv6zero,
 			Mask: net.CIDRMask(0, 128),

--- a/internal/forwarder/gtp5g.go
+++ b/internal/forwarder/gtp5g.go
@@ -3,7 +3,6 @@ package forwarder
 import (
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -174,11 +173,14 @@ func (g *Gtp5g) Link() *Gtp5gLink {
 	return g.link
 }
 
-func (g *Gtp5g) newFlowDesc(s string) (nl.AttrList, error) {
+func (g *Gtp5g) newFlowDesc(s string, swapSrcDst bool) (nl.AttrList, error) {
 	var attrs nl.AttrList
 	fd, err := ParseFlowDesc(s)
 	if err != nil {
 		return nil, err
+	}
+	if swapSrcDst {
+		fd.Src, fd.Dst = fd.Dst, fd.Src
 	}
 	switch fd.Action {
 	case "permit":
@@ -250,22 +252,7 @@ func convertSlice(ports [][]uint16) []byte {
 	return b
 }
 
-func swapSrcDst(fdStr string) (string, error) {
-	strs1 := strings.Split(fdStr, "from")
-	if len(strs1) != 2 {
-		return "", fmt.Errorf("invalid flow description format")
-	}
-
-	strs2 := strings.Split(strs1[1], "to")
-	if len(strs2) != 2 {
-		return "", fmt.Errorf("invalid flow description format")
-	}
-
-	ret := strs1[0] + "from" + strs2[1] + " to" + strs2[0]
-	return ret, nil
-}
-
-func (g *Gtp5g) newSdfFilter(i *ie.IE, sourceInterface uint8) (nl.AttrList, error) {
+func (g *Gtp5g) newSdfFilter(i *ie.IE, srcIf uint8) (nl.AttrList, error) {
 	var attrs nl.AttrList
 
 	v, err := i.SDFFilter()
@@ -274,15 +261,8 @@ func (g *Gtp5g) newSdfFilter(i *ie.IE, sourceInterface uint8) (nl.AttrList, erro
 	}
 
 	if v.HasFD() {
-		fdStr := v.FlowDescription
-		if sourceInterface == ie.SrcInterfaceAccess {
-			fdStr, err = swapSrcDst(fdStr)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		fd, err := g.newFlowDesc(fdStr)
+		swapSrcDst := (srcIf == ie.SrcInterfaceAccess)
+		fd, err := g.newFlowDesc(v.FlowDescription, swapSrcDst)
 		if err != nil {
 			return nil, err
 		}
@@ -336,21 +316,20 @@ func (g *Gtp5g) newPdi(i *ie.IE) (nl.AttrList, error) {
 		return nil, err
 	}
 
-	var sourceInterface uint8
-	var sdfFilterIE *ie.IE
-
-L:
+	var srcIf uint8
+	var sdfIEs []*ie.IE
 	for _, x := range ies {
 		switch x.Type {
 		case ie.SourceInterface:
-			sourceInterface, err = x.SourceInterface()
+			v, err := x.SourceInterface()
 			if err != nil {
-				break L
+				break
 			}
+			srcIf = v
 		case ie.FTEID:
 			v, err := x.FTEID()
 			if err != nil {
-				break L
+				break
 			}
 			attrs = append(attrs, nl.Attr{
 				Type: gtp5gnl.PDI_F_TEID,
@@ -369,20 +348,20 @@ L:
 		case ie.UEIPAddress:
 			v, err := x.UEIPAddress()
 			if err != nil {
-				break L
+				break
 			}
 			attrs = append(attrs, nl.Attr{
 				Type:  gtp5gnl.PDI_UE_ADDR_IPV4,
 				Value: nl.AttrBytes(v.IPv4Address),
 			})
 		case ie.SDFFilter:
-			sdfFilterIE = x
+			sdfIEs = append(sdfIEs, x)
 		case ie.ApplicationID:
 		}
 	}
 
-	if sdfFilterIE != nil {
-		v, err := g.newSdfFilter(sdfFilterIE, sourceInterface)
+	for _, x := range sdfIEs {
+		v, err := g.newSdfFilter(x, srcIf)
 		if err == nil {
 			attrs = append(attrs, nl.Attr{
 				Type:  gtp5gnl.PDI_SDF_FILTER,


### PR DESCRIPTION
## Description
This PR fixed 2 Issues:
### 1. NULL SDF
- When SDF's flow description is set to `permit out ip from any to assigned`
- use `sudo ./gtp5g-tunnel list pdr` to observe, SDF is **NULL**
![image](https://github.com/free5gc/go-upf/assets/46628572/5dd09473-3720-4426-ab2e-4ea0fb2eea12)

### 2. Wrong Source, Destination IP/Port
Since SMF created PDR which flow description should be same for both UL/DL, it's necessary to swap src, dst in UPF for UL before set rule into gtp5g.

### Relative Spec
- TS 29.212 5.4.2
![image](https://github.com/free5gc/go-upf/assets/46628572/51ae88bd-94b8-4a1d-a0c2-4766eb680f17)
- TS 29.244 5.2.1A.2A
![image](https://github.com/free5gc/go-upf/assets/46628572/cff278d9-9af3-452a-a30a-f6899c43dbcd)


