### PR TITLE
debug: add Created PDR in PFCP Session Establishment Response

### DIFF
--- a/internal/pfcp/session.go
+++ b/internal/pfcp/session.go
@@ -100,6 +100,7 @@ func (s *PfcpServer) handleSessionEstablishmentRequest(
 		newIeNodeID(s.nodeID),
 		ie.NewCause(ie.CauseRequestAccepted),
 		ie.NewFSEID(sess.LocalID, v4, v6),
+		ie.NewCreatePDR(req.CreatePDR...),
 	)
 
 	err = s.sendRspTo(rsp, addr)


### PR DESCRIPTION

## Decscription
According to 3GPP R15, R16, R17 spec , the created PDR should appear in "PFCP Session Establishment Response". 

![image](https://github.com/free5gc/go-upf/assets/148625142/a5a884f1-7d27-4916-b8c3-f966d4b5f37b)

## Note
I added CreatePDR IE from SMF to the UPF response. I checked my code and here are the results.

![image](https://github.com/free5gc/go-upf/assets/148625142/d1e85a70-5c93-406b-9d77-fc54413236d6)

