### PR TITLE
chore: change urr file exist log to warn

### DIFF
--- a/internal/pfcp/session.go
+++ b/internal/pfcp/session.go
@@ -2,6 +2,7 @@ package pfcp
 
 import (
 	"net"
+	"strings"
 
 	"github.com/wmnsk/go-pfcp/ie"
 	"github.com/wmnsk/go-pfcp/message"
@@ -186,7 +187,11 @@ func (s *PfcpServer) handleSessionModificationRequest(
 	for _, i := range req.CreateURR {
 		err = sess.CreateURR(i)
 		if err != nil {
-			sess.log.Errorf("Mod CreateURR error: %+v", err)
+			if strings.Contains(err.Error(), "file exists") {
+				sess.log.Warnf("Mod CreateURR error: %+v", err)
+			} else {
+				sess.log.Errorf("Mod CreateURR error: %+v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
In ULCL script, the UPF will print this URR file exist log as an error log. But in actual, this is not functional error, both the data plane and the control plane work well as expect.

<img width="1263" height="478" alt=" " src="https://github.com/user-attachments/assets/cad07001-b53f-4056-8801-d981fc08d09a" />


After discussing with @lyz508, this should be rewrite as an warn log.