### PR TITLE
Prevent nil reference when SMF respond with SEID 0

### DIFF
--- a/internal/pfcp/node.go
+++ b/internal/pfcp/node.go
@@ -641,6 +641,9 @@ func (n *LocalNode) Sess(lSeid uint64) (*Sess, error) {
 
 func (n *LocalNode) RemoteSess(rSeid uint64, addr net.Addr) (*Sess, error) {
 	for _, s := range n.sess {
+		if s == nil {
+			continue
+		}
 		if s.RemoteID == rSeid && s.rnode.addr.String() == addr.String() {
 			return s, nil
 		}


### PR DESCRIPTION
When the SMF responds to a UPF Session Report with SEID=0, the UPF iterates through session objects in LocalNode and accesses fields (e.g., RemoteID) without verifying that the session object is non‑null, which can cause a crash. This PR adds the missing null check to prevent the crash.

```

│ 2025-11-11T11:24:34.879405704Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879472434Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879493554Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879543564Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879868534Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879888304Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879953074Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.879977134Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880020314Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880077274Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880125924Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880376314Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880421844Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880463824Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880499854Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880700034Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880777814Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880842794Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880878824Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.880953334Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881044254Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881144104Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881383254Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881438984Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881532324Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881581444Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881720864Z [INFO][UPF][PFCP][LAddr:10.100.50.241:8805] handleSessionReportResponse                                                                                              │
│ 2025-11-11T11:24:34.881745944Z [WARN][UPF][PFCP][LAddr:10.100.50.241:8805] rsp SEID is 0; no this session on remote; delete it on local                                                             │
│ 2025-11-11T11:24:34.881856754Z [FATA][UPF][PFCP][LAddr:10.100.50.241:8805] panic: runtime error: invalid memory address or nil pointer dereference                                                  │
│ goroutine 20 [running]:                                                                                                                                                                             │
│ runtime/debug.Stack()                                                                                                                                                                               │
│     /usr/local/go/src/runtime/debug/stack.go:26 +0x5e                                                                                                                                               │
│ github.com/free5gc/go-upf/internal/pfcp.(*PfcpServer).main.func1()                                                                                                                                  │
│     /go/src/free5gc/NFs/upf/internal/pfcp/pfcp.go:86 +0x4a                                                                                                                                          │
│ panic({0x8dc440?, 0xdac920?})                                                                                                                                                                       │
│     /usr/local/go/src/runtime/panic.go:792 +0x132                                                                                                                                                   │
│ github.com/free5gc/go-upf/internal/pfcp.(*LocalNode).RemoteSess(0xc000278310?, 0x11d, {0xa27410, 0xc000a8fe30})                                                                                     │
│     /go/src/free5gc/NFs/upf/internal/pfcp/node.go:644 +0x4f                                                                                                                                         │
│ github.com/free5gc/go-upf/internal/pfcp.(*PfcpServer).handleSessionReportResponse(0xc0000c60d0, 0xc0007acba0, {0xa27410, 0xc000a8fe30}, {0xa2bc20, 0xc00057fae0})                                   │
│     /go/src/free5gc/NFs/upf/internal/pfcp/session.go:412 +0x186                                                                                                                                     │
│ github.com/free5gc/go-upf/internal/pfcp.(*PfcpServer).rspDispacher(0xc000571680?, {0xa2be00?, 0xc0007acba0?}, {0xa27410?, 0xc000a8fe30?}, {0xa2bc20?, 0xc00057fae0?})                               │
│     /go/src/free5gc/NFs/upf/internal/pfcp/dispacher.go:35 +0x65                                                                                                                                     │
│ github.com/free5gc/go-upf/internal/pfcp.(*PfcpServer).main(0xc0000c60d0, 0xc00009de10)                                                                                                              │
│     /go/src/free5gc/NFs/upf/internal/pfcp/pfcp.go:161 +0xa45                                                                                                                                        │
│ created by github.com/free5gc/go-upf/internal/pfcp.(*PfcpServer).Start in goroutine 1                                                                                                               │
│     /go/src/free5gc/NFs/upf/internal/pfcp/pfcp.go:222 +0xb3 
```