### PR TITLE
validate mandatory PDR fields and improve PDI parse handling

### DIFF
--- a/internal/forwarder/gtp5g.go
+++ b/internal/forwarder/gtp5g.go
@@ -542,7 +542,8 @@ func (g *Gtp5g) UpdatePDR(lSeid uint64, req *ie.IE) error {
 		case ie.PDI:
 			v, err := g.newPdi(i)
 			if err != nil {
-				return errors.Wrap(err, "UpdatePDR: failed to parse PDI")
+				logger.FwderLog.Warnf("UpdatePDR: failed to parse PDI: %v", err)
+				break
 			}
 			if v != nil {
 				attrs = append(attrs, nl.Attr{

--- a/internal/pfcp/node.go
+++ b/internal/pfcp/node.go
@@ -101,15 +101,21 @@ func (s *Sess) CreatePDR(req *ie.IE) error {
 	}
 
 	var pdrid uint16
+	var hasPDRID, hasPrecedence, hasPDI bool
 	urrids := make(map[uint32]struct{})
 	for _, i := range ies {
 		switch i.Type {
 		case ie.PDRID:
 			v, err1 := i.PDRID()
 			if err1 != nil {
-				break
+				return errors.Errorf("CreatePDR: failed to parse PDR ID: %v", err1)
 			}
 			pdrid = v
+			hasPDRID = true
+		case ie.Precedence:
+			hasPrecedence = true
+		case ie.PDI:
+			hasPDI = true
 		case ie.URRID:
 			v, err1 := i.URRID()
 			if err1 != nil {
@@ -121,6 +127,16 @@ func (s *Sess) CreatePDR(req *ie.IE) error {
 				urrInfo.refPdrNum++
 			}
 		}
+	}
+
+	if !hasPDRID {
+		return errors.New("CreatePDR: missing mandatory IE: PDR ID")
+	}
+	if !hasPrecedence {
+		return errors.Errorf("CreatePDR: PDR(%#x) missing mandatory IE: Precedence", pdrid)
+	}
+	if !hasPDI {
+		return errors.Errorf("CreatePDR: PDR(%#x) missing mandatory IE: PDI", pdrid)
 	}
 
 	s.PDRIDs[pdrid] = &PDRInfo{

--- a/internal/pfcp/node.go
+++ b/internal/pfcp/node.go
@@ -183,15 +183,17 @@ func (s *Sess) UpdatePDR(req *ie.IE) ([]report.USAReport, error) {
 	}
 
 	var pdrid uint16
+	var hasPDRID bool
 	newUrrids := make(map[uint32]struct{})
 	for _, i := range ies {
 		switch i.Type {
 		case ie.PDRID:
 			v, err1 := i.PDRID()
 			if err1 != nil {
-				break
+				return nil, errors.Errorf("UpdatePDR: failed to parse PDR ID: %v", err1)
 			}
 			pdrid = v
+			hasPDRID = true
 		case ie.URRID:
 			v, err1 := i.URRID()
 			if err1 != nil {
@@ -199,6 +201,10 @@ func (s *Sess) UpdatePDR(req *ie.IE) ([]report.USAReport, error) {
 			}
 			newUrrids[v] = struct{}{}
 		}
+	}
+
+	if !hasPDRID {
+		return nil, errors.New("UpdatePDR: missing mandatory IE: PDR ID")
 	}
 
 	pdrInfo, ok := s.PDRIDs[pdrid]


### PR DESCRIPTION
This pull request improves error handling and validation for PDR (Packet Detection Rule) creation and update logic in the PFCP node and GTP5G forwarder. The main focus is on ensuring mandatory Information Elements (IEs) are present and providing clearer error messages when they are missing or malformed.

**Mandatory IE validation and error handling improvements:**

* Added explicit checks for mandatory IEs (`PDRID`, `Precedence`, and `PDI`) during PDR creation in `Sess.CreatePDR`, returning descriptive errors if any are missing. 
* Enhanced error handling in `Sess.CreatePDR` and `Sess.UpdatePDR` to immediately return errors when parsing of `PDRID` fails, rather than silently skipping the error. 
* Added a check for the presence of `PDRID` in `Sess.UpdatePDR`, returning an error if it is missing.

**Logging improvements:**

* In `Gtp5g.UpdatePDR`, changed error handling for PDI parsing to log a warning instead of returning an error, allowing processing to continue.