### PR TITLE
fix/issue796

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/davecgh/go-spew v1.1.1
 	github.com/free5gc/go-gtp5gnl v1.6.1
-	github.com/free5gc/util v1.3.1
+	github.com/free5gc/util v1.3.2-0.20260228091348-fb7d1127055f
 	github.com/hashicorp/go-version v1.6.0
 	github.com/khirono/go-genl v1.0.1
 	github.com/khirono/go-nl v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/free5gc/go-gtp5gnl v1.6.1 h1:o0qQoWlpHk28dkxBO3I3NyA9rsk29xwtjWnulKa68+I=
 github.com/free5gc/go-gtp5gnl v1.6.1/go.mod h1:1fFOCohI1urnW9ftZ9O7EZPQItywn+8IVf9vYnwq8AM=
-github.com/free5gc/util v1.3.1 h1:5j5Exvp42Ow3zNP2aaAp68MSne6BcaCF4/cekXYUS6w=
-github.com/free5gc/util v1.3.1/go.mod h1:qsv/ez8YhI+pO8bjNiZWXc2xmRE3XuEIa0EDTCPkSy0=
+github.com/free5gc/util v1.3.2-0.20260228091348-fb7d1127055f h1:QFcwuG8Taq2JkDuzu/02ftmgQ7jkDqJRbtGfe+w041M=
+github.com/free5gc/util v1.3.2-0.20260228091348-fb7d1127055f/go.mod h1:qsv/ez8YhI+pO8bjNiZWXc2xmRE3XuEIa0EDTCPkSy0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/internal/forwarder/gtp5g.go
+++ b/internal/forwarder/gtp5g.go
@@ -612,7 +612,7 @@ func (g *Gtp5g) newForwardingParameter(ies []*ie.IE) (nl.AttrList, error) {
 			v, err := pfcp.ParseOuterHeaderCreation(x.Payload)
 			if err != nil {
 				g.log.Warnf("Invalid OuterHeaderCreation IE: %v", err)
-				return nil, err
+				break
 			}
 			var hc nl.AttrList
 			hc = append(hc, nl.Attr{

--- a/internal/forwarder/gtp5g.go
+++ b/internal/forwarder/gtp5g.go
@@ -22,6 +22,7 @@ import (
 	"github.com/free5gc/go-upf/internal/report"
 	"github.com/free5gc/go-upf/pkg/factory"
 	logger_util "github.com/free5gc/util/logger"
+	"github.com/free5gc/util/pfcp"
 )
 
 const (
@@ -255,20 +256,16 @@ func convertSlice(ports [][]uint16) []byte {
 
 func (g *Gtp5g) newSdfFilter(i *ie.IE, srcIf uint8) (nl.AttrList, error) {
 	var attrs nl.AttrList
-
 	// i.Payload[0] corresponds to Octet 5 (Flags) in the spec
 	flags := i.Payload[0]
 	hasFD := (flags & 0x01) != 0 // Bit 1: Flow Description
 	offset := 2
-
 	if hasFD {
 		if len(i.Payload) < offset+2 {
 			return nil, errors.New("SDF Filter IE with FD flag needs Length of Flow Description")
 		}
 		// Read FDLength from i.Payload[2-3] (Octets 7-8 in spec)
 		fdLength := uint16(i.Payload[offset])<<8 | uint16(i.Payload[offset+1])
-
-		// Validate FDLength doesn't exceed available payload
 		// Flow Description data starts at i.Payload[4] (Octet 9)
 		flowDescStart := offset + 2
 		availableBytes := len(i.Payload) - flowDescStart
@@ -278,13 +275,10 @@ func (g *Gtp5g) newSdfFilter(i *ie.IE, srcIf uint8) (nl.AttrList, error) {
 				fdLength, availableBytes)
 		}
 	}
-
-	// Now it's safe to parse - the payload has been pre-validated
 	v, err := i.SDFFilter()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse SDF Filter")
 	}
-
 	// Process validated SDF Filter fields
 	if v.HasFD() {
 		swapSrcDst := (srcIf == ie.SrcInterfaceAccess)
@@ -297,7 +291,6 @@ func (g *Gtp5g) newSdfFilter(i *ie.IE, srcIf uint8) (nl.AttrList, error) {
 			Value: fd,
 		})
 	}
-
 	if v.HasTTC() {
 		// TODO:
 		// v.ToSTrafficClass string
@@ -615,16 +608,18 @@ func (g *Gtp5g) newForwardingParameter(ies []*ie.IE) (nl.AttrList, error) {
 		case ie.DestinationInterface:
 		case ie.NetworkInstance:
 		case ie.OuterHeaderCreation:
-			v, err := x.OuterHeaderCreation()
+			// Use parser from util/pfcp to work around go-pfcp bug with C-TAG/S-TAG
+			v, err := pfcp.ParseOuterHeaderCreation(x.Payload)
 			if err != nil {
-				break
+				g.log.Warnf("Invalid OuterHeaderCreation IE: %v", err)
+				return nil, err
 			}
 			var hc nl.AttrList
 			hc = append(hc, nl.Attr{
 				Type:  gtp5gnl.OUTER_HEADER_CREATION_DESCRIPTION,
 				Value: nl.AttrU16(v.OuterHeaderCreationDescription),
 			})
-			if x.HasTEID() {
+			if v.HasTEID() {
 				hc = append(hc, nl.Attr{
 					Type:  gtp5gnl.OUTER_HEADER_CREATION_O_TEID,
 					Value: nl.AttrU32(v.TEID),
@@ -640,7 +635,7 @@ func (g *Gtp5g) newForwardingParameter(ies []*ie.IE) (nl.AttrList, error) {
 					Value: nl.AttrU16(v.PortNumber),
 				})
 			}
-			if x.HasIPv4() {
+			if v.HasIPv4() {
 				hc = append(hc, nl.Attr{
 					Type:  gtp5gnl.OUTER_HEADER_CREATION_PEER_ADDR_IPV4,
 					Value: nl.AttrBytes(v.IPv4Address),


### PR DESCRIPTION
**Dependency update:**

* Upgraded `github.com/free5gc/util` from version `v1.3.1` to a newer commit, `v1.3.2-0.20260228091348-fb7d1127055f`, in `go.mod`, ensuring access to recent bug fixes and features.

**Parser improvements and bug fixes:**

* In `internal/forwarder/gtp5g.go`, switched Outer Header Creation parsing to use `pfcp.ParseOuterHeaderCreation` from `free5gc/util/pfcp` instead of the previous method to work around a known bug with C-TAG/S-TAG handling. This change also improves error handling and logging for invalid IEs. 