### PR TITLE
feat: implement Nupf_EventExposureService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVI
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/exposure/datamodel.go
+++ b/internal/exposure/datamodel.go
@@ -1,0 +1,134 @@
+// Package exposure implements the Nupf_EventExposure service defined in 3GPP TS 29.564.
+package exposure
+
+import (
+	"net"
+	"time"
+)
+
+// EventType enumerates the UPF event types defined in 3GPP TS 29.564 clause 5.6.
+type EventType string
+
+const (
+	EventTypeUserDataUsageMeasures EventType = "USER_DATA_USAGE_MEASURES"
+	EventTypeUserDataUsageTrends   EventType = "USER_DATA_USAGE_TRENDS"
+	EventTypeQosMonitoring         EventType = "QOS_MONITORING"
+	EventTypeTscMngtInfo           EventType = "TSC_MNGT_INFO"
+)
+
+// UpfEventTrigger specifies when event notifications are sent.
+type UpfEventTrigger string
+
+const (
+	TriggerOneTime  UpfEventTrigger = "ONE_TIME"
+	TriggerPeriodic UpfEventTrigger = "PERIODIC"
+)
+
+// MeasurementType specifies what to measure for USER_DATA_USAGE_*.
+type MeasurementType string
+
+const (
+	MeasurementVolume     MeasurementType = "VOLUME"
+	MeasurementThroughput MeasurementType = "THROUGHPUT"
+)
+
+// GranularityOfMeasurement specifies measurement granularity.
+type GranularityOfMeasurement string
+
+const (
+	GranularityPerUe     GranularityOfMeasurement = "PER_UE"
+	GranularityPerFlow   GranularityOfMeasurement = "PER_FLOW"
+	GranularityPerAppId  GranularityOfMeasurement = "PER_APP_ID"
+	GranularityAggregate GranularityOfMeasurement = "AGGREGATE"
+)
+
+// Snssai represents a Single Network Slice Selection Assistance Information.
+type Snssai struct {
+	Sst int32  `json:"sst"`
+	Sd  string `json:"sd,omitempty"`
+}
+
+// UpfEvent describes a single event to subscribe to (TS 29.564 clause 6.1.6.2.3).
+type UpfEvent struct {
+	Type            EventType         `json:"type"`
+	ImmediateFlag   bool              `json:"immediateFlag,omitempty"`
+	MeasurementType []MeasurementType `json:"measurementTypes,omitempty"`
+	// Granularity for usage measurement reports
+	Granularity GranularityOfMeasurement `json:"granularityOfMeasurement,omitempty"`
+}
+
+// UpfEventMode contains the subscription's trigger and period (TS 29.564 clause 6.1.6.2.4).
+type UpfEventMode struct {
+	Trigger    UpfEventTrigger `json:"trigger"`
+	RepPeriod  *int32          `json:"repPeriod,omitempty"` // seconds, required for PERIODIC
+	MaxReports *int32          `json:"maxReports,omitempty"`
+}
+
+// UpfEventSubscription is the per-subscription data for Nupf_EventExposure
+// (TS 29.564 clause 6.1.6.2.2). Sessions are identified by UE IP address, not TEID.
+type UpfEventSubscription struct {
+	EventNotifyUri string       `json:"eventNotifyUri"`
+	NotifCorrId    string       `json:"notifyCorrelationId"`
+	EventList      []UpfEvent   `json:"eventList"`
+	EventMode      UpfEventMode `json:"eventReportingMode"`
+	UeIpAddress    net.IP       `json:"ueIpAddress,omitempty"`
+	AnyUe          bool         `json:"anyUe,omitempty"`
+	Dnn            string       `json:"dnn,omitempty"`
+	Snssai         *Snssai      `json:"snssai,omitempty"`
+	NfId           string       `json:"nfId,omitempty"`
+}
+
+// CreateEventSubscription is the request body for POST /ee-subscriptions.
+type CreateEventSubscription struct {
+	Subscription UpfEventSubscription `json:"subscription"`
+}
+
+// CreatedEventSubscription is the 201 response body (TS 29.564 clause 6.1.6.3.1).
+type CreatedEventSubscription struct {
+	SubscriptionId string               `json:"subscriptionId"`
+	Subscription   UpfEventSubscription `json:"subscription"`
+	// ReportList may contain an immediate report if immediateFlag is true.
+	ReportList []NotificationData `json:"reportList,omitempty"`
+}
+
+// VolumeMeasurement holds UL/DL/Total volume counts (bytes).
+type VolumeMeasurement struct {
+	TotalVolume    *uint64 `json:"totalVolume,omitempty"`
+	UplinkVolume   *uint64 `json:"ulVolume,omitempty"`
+	DownlinkVolume *uint64 `json:"dlVolume,omitempty"`
+	TotalNbOfPkts  *uint64 `json:"totalNbOfPkts,omitempty"`
+	UlNbOfPkts     *uint64 `json:"ulNbOfPkts,omitempty"`
+	DlNbOfPkts     *uint64 `json:"dlNbOfPkts,omitempty"`
+}
+
+// ThroughputMeasurement holds UL/DL average throughput in bit/s.
+type ThroughputMeasurement struct {
+	UlThroughput *uint64 `json:"ulThroughput,omitempty"`
+	DlThroughput *uint64 `json:"dlThroughput,omitempty"`
+}
+
+// UserDataUsageMeasurements holds the measurement data for USER_DATA_USAGE_MEASURES event.
+type UserDataUsageMeasurements struct {
+	VolumeMeasurement     *VolumeMeasurement     `json:"volumeMeasurement,omitempty"`
+	ThroughputMeasurement *ThroughputMeasurement `json:"throughputMeasurement,omitempty"`
+	ApplicationId         string                 `json:"appId,omitempty"`
+}
+
+// NotificationItem is one item in a notification (per session/UE).
+type NotificationItem struct {
+	SourceUeIpAddress net.IP                      `json:"sourceUeIpAddress,omitempty"`
+	TimeStamp         time.Time                   `json:"timeStamp"`
+	EventType         EventType                   `json:"eventType"`
+	UsageData         []UserDataUsageMeasurements `json:"usageData,omitempty"`
+}
+
+// NotificationData is the body of a notification POST sent to eventNotifyUri.
+type NotificationData struct {
+	NotifCorrId       string             `json:"notifyCorrelationId"`
+	NotificationItems []NotificationItem `json:"notificationItems"`
+}
+
+// ModifySubscriptionRequest is the body of PATCH /ee-subscriptions/{subscriptionId}.
+type ModifySubscriptionRequest struct {
+	Subscription UpfEventSubscription `json:"subscription"`
+}

--- a/internal/exposure/server.go
+++ b/internal/exposure/server.go
@@ -1,0 +1,436 @@
+package exposure
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/free5gc/go-upf/internal/logger"
+	"github.com/free5gc/go-upf/internal/report"
+)
+
+// PfcpInterface defines the subset of PfcpServer that the exposure server needs.
+type PfcpInterface interface {
+	AddMonitoringURR(lSeid uint64, urrid uint32, repPeriod time.Duration) error
+	RemoveMonitoringURR(lSeid uint64, urrid uint32) error
+}
+
+// NodeInterface gives access to sessions for subscription matching.
+type NodeInterface interface {
+	// GetAllSessions returns a snapshot of all active sessions.
+	// Each entry exposes at minimum: LocalID, UeIpAddr, Dnn.
+	GetAllSessions() []SessionInfo
+}
+
+// SessionInfo is the minimal session info the exposure server needs.
+type SessionInfo struct {
+	LocalID        uint64
+	UeIpAddr       net.IP
+	Dnn            string
+	ExistingURRIDs map[uint32]struct{}
+}
+
+// subscriptionRecord tracks the internal state of one Nupf_EventExposure subscription.
+type subscriptionRecord struct {
+	subID string
+	sub   UpfEventSubscription
+	// sessionURRs maps localSeid → monitoring URRID allocated for that session.
+	sessionURRs map[uint64]uint32
+}
+
+// Server is the Nupf_EventExposure HTTP server (3GPP TS 29.564).
+// It creates and manages monitoring URRs on PFCP sessions for matched UEs.
+type Server struct {
+	listenAddr string
+	pfcp       PfcpInterface
+	node       NodeInterface
+
+	mu   sync.RWMutex
+	subs map[string]*subscriptionRecord // key: subscriptionId
+
+	httpServer *http.Server
+}
+
+// NewServer creates a new exposure Server.
+func NewServer(listenAddr string, pfcp PfcpInterface, node NodeInterface) *Server {
+	s := &Server{
+		listenAddr: listenAddr,
+		pfcp:       pfcp,
+		node:       node,
+		subs:       make(map[string]*subscriptionRecord),
+	}
+	return s
+}
+
+// Run starts the HTTP server and blocks until ctx is cancelled.
+func (s *Server) Run(ctx context.Context) error {
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	router.Use(gin.Recovery())
+
+	v1 := router.Group("/nupf-ee/v1")
+	v1.POST("/ee-subscriptions", s.handleCreateSubscription)
+	v1.DELETE("/ee-subscriptions/:subscriptionId", s.handleDeleteSubscription)
+	v1.PATCH("/ee-subscriptions/:subscriptionId", s.handleModifySubscription)
+
+	srv := &http.Server{
+		Addr:    s.listenAddr,
+		Handler: router,
+	}
+	s.httpServer = srv
+
+	logger.ExposureLog.Infof("Nupf_EventExposure server listening on %s", s.listenAddr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+// HandleReport is called by the ReportMultiplexer for each SessReport.
+// It returns true if the report was fully consumed (belongs to a monitoring URR).
+func (s *Server) HandleReport(sr report.SessReport) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	consumed := false
+	for _, rec := range s.subs {
+		monURRID, ok := rec.sessionURRs[sr.SEID]
+		if !ok {
+			continue
+		}
+		for _, r := range sr.Reports {
+			usar, isUSA := r.(report.USAReport)
+			if !isUSA || usar.URRID != monURRID {
+				continue
+			}
+			// Build and send notification
+			s.sendNotification(rec, sr.SEID, usar)
+			consumed = true
+		}
+	}
+	return consumed
+}
+
+// sendNotification sends a Nupf_EventExposure notification to the subscriber's URI.
+func (s *Server) sendNotification(rec *subscriptionRecord, lSeid uint64, usar report.USAReport) {
+	item := buildNotificationItem(rec.sub, usar)
+	notif := NotificationData{
+		NotifCorrId:       rec.sub.NotifCorrId,
+		NotificationItems: []NotificationItem{item},
+	}
+
+	body, err := json.Marshal(notif)
+	if err != nil {
+		logger.ExposureLog.Warnf("sendNotification marshal error: %v", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rec.sub.EventNotifyUri, bytes.NewReader(body))
+	if err != nil {
+		logger.ExposureLog.Warnf("sendNotification create request error: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.ExposureLog.Warnf("sendNotification POST to %s error: %v", rec.sub.EventNotifyUri, err)
+		return
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			logger.ExposureLog.Warnf("failed to close response body: %v", errClose)
+		}
+	}()
+	logger.ExposureLog.Infof("Sent notification to %s for sub %s, status %d",
+		rec.sub.EventNotifyUri, rec.subID, resp.StatusCode)
+}
+
+func buildNotificationItem(sub UpfEventSubscription, usar report.USAReport) NotificationItem {
+	item := NotificationItem{
+		SourceUeIpAddress: sub.UeIpAddress,
+		TimeStamp:         time.Now().UTC(),
+	}
+	// Determine primary event type from subscription
+	if len(sub.EventList) > 0 {
+		item.EventType = sub.EventList[0].Type
+	} else {
+		item.EventType = EventTypeUserDataUsageMeasures
+	}
+
+	vol := usar.VolumMeasure
+	totalVol := vol.TotalVolume
+	ulVol := vol.UplinkVolume
+	dlVol := vol.DownlinkVolume
+	item.UsageData = []UserDataUsageMeasurements{
+		{
+			VolumeMeasurement: &VolumeMeasurement{
+				TotalVolume:    &totalVol,
+				UplinkVolume:   &ulVol,
+				DownlinkVolume: &dlVol,
+			},
+		},
+	}
+	return item
+}
+
+// --- HTTP handlers ---
+
+// handleCreateSubscription handles POST /nupf-ee/v1/ee-subscriptions.
+func (s *Server) handleCreateSubscription(c *gin.Context) {
+	s.TestHandleCreate(c)
+}
+
+// TestHandleCreate is exported for test router wiring.
+func (s *Server) TestHandleCreate(c *gin.Context) {
+	var req CreateEventSubscription
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"cause": err.Error()})
+		return
+	}
+
+	created, status, err := s.CreateSubscription(req)
+	if err != nil {
+		c.JSON(status, gin.H{"cause": err.Error()})
+		return
+	}
+
+	locationURI := fmt.Sprintf("%s/nupf-ee/v1/ee-subscriptions/%s",
+		c.Request.Host, created.SubscriptionId)
+	c.Header("Location", locationURI)
+	c.JSON(http.StatusCreated, created)
+}
+
+// handleDeleteSubscription handles DELETE /nupf-ee/v1/ee-subscriptions/{subscriptionId}.
+func (s *Server) handleDeleteSubscription(c *gin.Context) {
+	s.TestHandleDelete(c)
+}
+
+// TestHandleDelete is exported for test router wiring.
+func (s *Server) TestHandleDelete(c *gin.Context) {
+	subID := c.Param("subscriptionId")
+	status, err := s.DeleteSubscription(subID)
+	if err != nil {
+		c.JSON(status, gin.H{"cause": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// handleModifySubscription handles PATCH /nupf-ee/v1/ee-subscriptions/{subscriptionId}.
+func (s *Server) handleModifySubscription(c *gin.Context) {
+	s.TestHandleModify(c)
+}
+
+// TestHandleModify is exported for test router wiring.
+func (s *Server) TestHandleModify(c *gin.Context) {
+	subID := c.Param("subscriptionId")
+	var req ModifySubscriptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"cause": err.Error()})
+		return
+	}
+
+	modified, status, err := s.modifySubscription(subID, req)
+	if err != nil {
+		c.JSON(status, gin.H{"cause": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, modified)
+}
+
+// --- Subscription logic ---
+
+// CreateSubscription implements subscription creation logic for both HTTP handler and tests.
+func (s *Server) CreateSubscription(req CreateEventSubscription) (CreatedEventSubscription, int, error) {
+	sub := req.Subscription
+	sessions := s.node.GetAllSessions()
+
+	// Find sessions that match the subscription criteria
+	matched := matchingSessions(sessions, sub)
+	if len(matched) == 0 {
+		return CreatedEventSubscription{}, http.StatusNotFound,
+			fmt.Errorf("no matching PDU sessions found")
+	}
+
+	repPeriod := repPeriodFromMode(sub.EventMode)
+	subID := uuid.New().String()
+	rec := &subscriptionRecord{
+		subID:       subID,
+		sub:         sub,
+		sessionURRs: make(map[uint64]uint32),
+	}
+
+	for _, sess := range matched {
+		urrid := allocateURRID(sess.ExistingURRIDs)
+		if err := s.pfcp.AddMonitoringURR(sess.LocalID, urrid, repPeriod); err != nil {
+			logger.ExposureLog.Warnf("AddMonitoringURR lSeid=%d urrid=%d: %v", sess.LocalID, urrid, err)
+			continue
+		}
+		rec.sessionURRs[sess.LocalID] = urrid
+	}
+
+	if len(rec.sessionURRs) == 0 {
+		return CreatedEventSubscription{}, http.StatusInternalServerError,
+			fmt.Errorf("failed to add monitoring URR to any session")
+	}
+
+	s.mu.Lock()
+	s.subs[subID] = rec
+	s.mu.Unlock()
+
+	return CreatedEventSubscription{
+		SubscriptionId: subID,
+		Subscription:   sub,
+	}, http.StatusCreated, nil
+}
+
+// DeleteSubscription implements subscription deletion logic for both HTTP handler and tests.
+func (s *Server) DeleteSubscription(subID string) (int, error) {
+	s.mu.Lock()
+	rec, ok := s.subs[subID]
+	if !ok {
+		s.mu.Unlock()
+		return http.StatusNotFound, fmt.Errorf("subscription %s not found", subID)
+	}
+	delete(s.subs, subID)
+	s.mu.Unlock()
+
+	for lSeid, urrid := range rec.sessionURRs {
+		if err := s.pfcp.RemoveMonitoringURR(lSeid, urrid); err != nil {
+			logger.ExposureLog.Warnf("RemoveMonitoringURR lSeid=%d urrid=%d: %v", lSeid, urrid, err)
+		}
+	}
+	return http.StatusNoContent, nil
+}
+
+func (s *Server) modifySubscription(subID string, req ModifySubscriptionRequest) (UpfEventSubscription, int, error) {
+	newSub := req.Subscription
+	matches := matchingSessions(s.node.GetAllSessions(), newSub)
+	if len(matches) == 0 {
+		return UpfEventSubscription{}, http.StatusNotFound, errors.New("no matching PDU session for subscription")
+	}
+
+	repPeriod := repPeriodFromMode(newSub.EventMode)
+	newSessionURRs := make(map[uint64]uint32, len(matches))
+
+	s.mu.Lock()
+	rec, ok := s.subs[subID]
+	if !ok {
+		s.mu.Unlock()
+		return UpfEventSubscription{}, http.StatusNotFound, fmt.Errorf("subscription %s not found", subID)
+	}
+	oldSessionURRs := make(map[uint64]uint32, len(rec.sessionURRs))
+	for lSeid, urrid := range rec.sessionURRs {
+		oldSessionURRs[lSeid] = urrid
+	}
+	s.mu.Unlock()
+
+	for _, sess := range matches {
+		existing := make(map[uint32]struct{}, len(sess.ExistingURRIDs)+1)
+		for id := range sess.ExistingURRIDs {
+			existing[id] = struct{}{}
+		}
+		if oldURRID, oldOK := oldSessionURRs[sess.LocalID]; oldOK {
+			existing[oldURRID] = struct{}{}
+		}
+		urrid := allocateURRID(existing)
+		if err := s.pfcp.AddMonitoringURR(sess.LocalID, urrid, repPeriod); err != nil {
+			logger.ExposureLog.Warnf("Modify AddMonitoringURR lSeid=%d urrid=%d: %v", sess.LocalID, urrid, err)
+			continue
+		}
+		newSessionURRs[sess.LocalID] = urrid
+	}
+	if len(newSessionURRs) == 0 {
+		return UpfEventSubscription{}, http.StatusInternalServerError,
+			errors.New("failed to add monitoring URR to any session")
+	}
+
+	for lSeid, urrid := range oldSessionURRs {
+		if err := s.pfcp.RemoveMonitoringURR(lSeid, urrid); err != nil {
+			logger.ExposureLog.Warnf("Modify RemoveMonitoringURR lSeid=%d urrid=%d: %v", lSeid, urrid, err)
+		}
+	}
+
+	s.mu.Lock()
+	rec, ok = s.subs[subID]
+	if !ok {
+		s.mu.Unlock()
+		for lSeid, urrid := range newSessionURRs {
+			if err := s.pfcp.RemoveMonitoringURR(lSeid, urrid); err != nil {
+				logger.ExposureLog.Warnf("rollback RemoveMonitoringURR lSeid=%d urrid=%d: %v", lSeid, urrid, err)
+			}
+		}
+		return UpfEventSubscription{}, http.StatusNotFound, fmt.Errorf("subscription %s not found", subID)
+	}
+	rec.sub = newSub
+	rec.sessionURRs = newSessionURRs
+	s.mu.Unlock()
+
+	return newSub, http.StatusOK, nil
+}
+
+// matchingSessions returns all sessions that match the subscription criteria.
+func matchingSessions(sessions []SessionInfo, sub UpfEventSubscription) []SessionInfo {
+	var result []SessionInfo
+	for _, sess := range sessions {
+		if sub.AnyUe {
+			result = append(result, sess)
+			continue
+		}
+		if sub.UeIpAddress != nil && sess.UeIpAddr != nil && sub.UeIpAddress.Equal(sess.UeIpAddr) {
+			result = append(result, sess)
+			continue
+		}
+		if sub.Dnn != "" && sub.Dnn == sess.Dnn {
+			result = append(result, sess)
+			continue
+		}
+	}
+	return result
+}
+
+// allocateURRID finds an unused URR ID starting from UpfMonitoringURRIDBase.
+// The monitoring range is 0xF0000001..0xFFFFFFFF to avoid collisions with SMF-allocated URRs.
+const monitoringURRIDBase uint32 = 0xF0000001
+
+func allocateURRID(existing map[uint32]struct{}) uint32 {
+	for id := monitoringURRIDBase; id != 0; id++ { // wraps around on overflow
+		if _, used := existing[id]; !used {
+			return id
+		}
+	}
+	// Fallback: should never happen with a 268M range
+	return monitoringURRIDBase
+}
+
+// repPeriodFromMode extracts the reporting period from UpfEventMode.
+// Returns 60s as default if no period is specified.
+func repPeriodFromMode(mode UpfEventMode) time.Duration {
+	if mode.RepPeriod != nil && *mode.RepPeriod > 0 {
+		return time.Duration(*mode.RepPeriod) * time.Second
+	}
+	return 60 * time.Second
+}

--- a/internal/exposure/server_test.go
+++ b/internal/exposure/server_test.go
@@ -1,0 +1,454 @@
+package exposure_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/go-upf/internal/exposure"
+	"github.com/free5gc/go-upf/internal/report"
+)
+
+// --- Fakes ---
+
+type fakePfcp struct {
+	mu      sync.Mutex
+	added   []addCall
+	removed []removeCall
+	addErr  error
+}
+
+type addCall struct {
+	lSeid     uint64
+	urrid     uint32
+	repPeriod time.Duration
+}
+
+type removeCall struct {
+	lSeid uint64
+	urrid uint32
+}
+
+func (f *fakePfcp) AddMonitoringURR(lSeid uint64, urrid uint32, repPeriod time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.added = append(f.added, addCall{lSeid, urrid, repPeriod})
+	return f.addErr
+}
+
+func (f *fakePfcp) RemoveMonitoringURR(lSeid uint64, urrid uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removed = append(f.removed, removeCall{lSeid, urrid})
+	return nil
+}
+
+type fakeNode struct {
+	sessions []exposure.SessionInfo
+}
+
+func (n *fakeNode) GetAllSessions() []exposure.SessionInfo {
+	return n.sessions
+}
+
+// --- Test helpers ---
+
+func newTestServer(pfcp exposure.PfcpInterface, node exposure.NodeInterface) *exposure.Server {
+	return exposure.NewServer("", pfcp, node)
+}
+
+// buildRouter creates a test gin router backed by a Server (for httptest usage).
+func buildRouter(srv *exposure.Server) http.Handler {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/nupf-ee/v1/ee-subscriptions", srv.TestHandleCreate)
+	r.DELETE("/nupf-ee/v1/ee-subscriptions/:subscriptionId", srv.TestHandleDelete)
+	r.PATCH("/nupf-ee/v1/ee-subscriptions/:subscriptionId", srv.TestHandleModify)
+	return r
+}
+
+// --- Tests ---
+
+func TestCreateSubscription_MatchByUeIP(t *testing.T) {
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	repPeriod := int32(30)
+	req := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-1",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic, RepPeriod: &repPeriod},
+			UeIpAddress:    ueIP,
+		},
+	}
+
+	created, status, err := srv.CreateSubscription(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, status)
+	assert.NotEmpty(t, created.SubscriptionId)
+
+	pfcpFake.mu.Lock()
+	defer pfcpFake.mu.Unlock()
+	require.Len(t, pfcpFake.added, 1)
+	assert.Equal(t, uint64(1), pfcpFake.added[0].lSeid)
+	assert.Equal(t, 30*time.Second, pfcpFake.added[0].repPeriod)
+}
+
+func TestCreateSubscription_AnyUe(t *testing.T) {
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: net.ParseIP("10.60.0.1").To4(), ExistingURRIDs: map[uint32]struct{}{}},
+			{LocalID: 2, UeIpAddr: net.ParseIP("10.60.0.2").To4(), ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	req := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-2",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			AnyUe:          true,
+		},
+	}
+
+	created, status, err := srv.CreateSubscription(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, status)
+	assert.NotEmpty(t, created.SubscriptionId)
+
+	pfcpFake.mu.Lock()
+	defer pfcpFake.mu.Unlock()
+	assert.Len(t, pfcpFake.added, 2)
+}
+
+func TestCreateSubscription_NoMatch(t *testing.T) {
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: net.ParseIP("10.60.0.1").To4(), ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	req := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-3",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			UeIpAddress:    net.ParseIP("10.60.99.99").To4(),
+		},
+	}
+
+	_, status, err := srv.CreateSubscription(req)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestDeleteSubscription(t *testing.T) {
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	req := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-4",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			UeIpAddress:    ueIP,
+		},
+	}
+
+	created, _, err := srv.CreateSubscription(req)
+	require.NoError(t, err)
+
+	status, err := srv.DeleteSubscription(created.SubscriptionId)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, status)
+
+	pfcpFake.mu.Lock()
+	defer pfcpFake.mu.Unlock()
+	require.Len(t, pfcpFake.removed, 1)
+	assert.Equal(t, uint64(1), pfcpFake.removed[0].lSeid)
+}
+
+func TestDeleteSubscription_NotFound(t *testing.T) {
+	srv := newTestServer(&fakePfcp{}, &fakeNode{})
+	status, err := srv.DeleteSubscription("nonexistent-id")
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestModifySubscription_ReprogramsMonitoringURR(t *testing.T) {
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	initialPeriod := int32(30)
+	created, _, err := srv.CreateSubscription(exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-mod-before",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic, RepPeriod: &initialPeriod},
+			UeIpAddress:    ueIP,
+		},
+	})
+	require.NoError(t, err)
+
+	pfcpFake.mu.Lock()
+	require.Len(t, pfcpFake.added, 1)
+	oldAdd := pfcpFake.added[0]
+	pfcpFake.mu.Unlock()
+
+	updatedPeriod := int32(10)
+	bodyBytes, err := json.Marshal(exposure.ModifySubscriptionRequest{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/new-notif",
+			NotifCorrId:    "corr-mod-after",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic, RepPeriod: &updatedPeriod},
+			UeIpAddress:    ueIP,
+		},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router := buildRouter(srv)
+	httpReq := httptest.NewRequestWithContext(context.Background(), http.MethodPatch,
+		"/nupf-ee/v1/ee-subscriptions/"+created.SubscriptionId,
+		bytes.NewReader(bodyBytes))
+	httpReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, httpReq)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var modified exposure.UpfEventSubscription
+	err = json.Unmarshal(w.Body.Bytes(), &modified)
+	require.NoError(t, err)
+	assert.Equal(t, "corr-mod-after", modified.NotifCorrId)
+
+	pfcpFake.mu.Lock()
+	defer pfcpFake.mu.Unlock()
+	require.Len(t, pfcpFake.added, 2)
+	require.Len(t, pfcpFake.removed, 1)
+	assert.Equal(t, uint64(1), pfcpFake.added[1].lSeid)
+	assert.Equal(t, 10*time.Second, pfcpFake.added[1].repPeriod)
+	assert.NotEqual(t, oldAdd.urrid, pfcpFake.added[1].urrid)
+	assert.Equal(t, oldAdd.urrid, pfcpFake.removed[0].urrid)
+}
+
+func TestModifySubscription_NoMatch(t *testing.T) {
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	created, _, err := srv.CreateSubscription(exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-mod-before",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			UeIpAddress:    ueIP,
+		},
+	})
+	require.NoError(t, err)
+
+	bodyBytes, err := json.Marshal(exposure.ModifySubscriptionRequest{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/new-notif",
+			NotifCorrId:    "corr-mod-after",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			UeIpAddress:    net.ParseIP("10.60.99.99").To4(),
+		},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router := buildRouter(srv)
+	httpReq := httptest.NewRequestWithContext(context.Background(), http.MethodPatch,
+		"/nupf-ee/v1/ee-subscriptions/"+created.SubscriptionId,
+		bytes.NewReader(bodyBytes))
+	httpReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, httpReq)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	pfcpFake.mu.Lock()
+	defer pfcpFake.mu.Unlock()
+	assert.Len(t, pfcpFake.added, 1)
+	assert.Len(t, pfcpFake.removed, 0)
+}
+
+func TestHandleReport_ConsumesMonitoringURR(t *testing.T) {
+	// We need a notification receiver
+	notifReceived := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notifReceived <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	req := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: ts.URL + "/notif",
+			NotifCorrId:    "corr-5",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			UeIpAddress:    ueIP,
+		},
+	}
+
+	created, _, err := srv.CreateSubscription(req)
+	require.NoError(t, err)
+	_ = created
+
+	// Get the URRID that was allocated
+	pfcpFake.mu.Lock()
+	require.Len(t, pfcpFake.added, 1)
+	allocatedURRID := pfcpFake.added[0].urrid
+	pfcpFake.mu.Unlock()
+
+	// Simulate a PFCP usage report for the monitoring URR
+	sr := report.SessReport{
+		SEID: 1,
+		Reports: []report.Report{
+			report.USAReport{
+				URRID: allocatedURRID,
+				VolumMeasure: report.VolumeMeasure{
+					TotalVolume:    1000,
+					UplinkVolume:   600,
+					DownlinkVolume: 400,
+				},
+			},
+		},
+	}
+
+	consumed := srv.HandleReport(sr)
+	assert.True(t, consumed)
+
+	select {
+	case <-notifReceived:
+		// Notification was sent
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected notification within 3 seconds")
+	}
+}
+
+func TestHTTPCreateSubscription(t *testing.T) {
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	repPeriod := int32(60)
+	body := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-6",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic, RepPeriod: &repPeriod},
+			UeIpAddress:    ueIP,
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router := buildRouter(srv)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/nupf-ee/v1/ee-subscriptions", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.NotEmpty(t, w.Header().Get("Location"))
+
+	var resp exposure.CreatedEventSubscription
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.SubscriptionId)
+}
+
+func TestHTTPDeleteSubscription(t *testing.T) {
+	ueIP := net.ParseIP("10.60.0.1").To4()
+	node := &fakeNode{
+		sessions: []exposure.SessionInfo{
+			{LocalID: 1, UeIpAddr: ueIP, ExistingURRIDs: map[uint32]struct{}{}},
+		},
+	}
+	pfcpFake := &fakePfcp{}
+	srv := newTestServer(pfcpFake, node)
+
+	// Create first
+	req := exposure.CreateEventSubscription{
+		Subscription: exposure.UpfEventSubscription{
+			EventNotifyUri: "http://localhost:9999/notif",
+			NotifCorrId:    "corr-7",
+			EventList:      []exposure.UpfEvent{{Type: exposure.EventTypeUserDataUsageMeasures}},
+			EventMode:      exposure.UpfEventMode{Trigger: exposure.TriggerPeriodic},
+			UeIpAddress:    ueIP,
+		},
+	}
+	created, _, err := srv.CreateSubscription(req)
+	require.NoError(t, err)
+
+	// Delete via HTTP
+	w := httptest.NewRecorder()
+	router := buildRouter(srv)
+	httpReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+		"/nupf-ee/v1/ee-subscriptions/"+created.SubscriptionId, nil)
+	router.ServeHTTP(w, httpReq)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -7,14 +7,15 @@ import (
 )
 
 var (
-	Log      *logrus.Logger
-	NfLog    *logrus.Entry
-	MainLog  *logrus.Entry
-	CfgLog   *logrus.Entry
-	PfcpLog  *logrus.Entry
-	BuffLog  *logrus.Entry
-	PerioLog *logrus.Entry
-	FwderLog *logrus.Entry
+	Log         *logrus.Logger
+	NfLog       *logrus.Entry
+	MainLog     *logrus.Entry
+	CfgLog      *logrus.Entry
+	PfcpLog     *logrus.Entry
+	BuffLog     *logrus.Entry
+	PerioLog    *logrus.Entry
+	FwderLog    *logrus.Entry
+	ExposureLog *logrus.Entry
 )
 
 func init() {
@@ -36,4 +37,5 @@ func init() {
 	BuffLog = NfLog.WithField(logger_util.FieldCategory, "BUFF")
 	PerioLog = NfLog.WithField(logger_util.FieldCategory, "Perio")
 	FwderLog = NfLog.WithField(logger_util.FieldCategory, "FWD")
+	ExposureLog = NfLog.WithField(logger_util.FieldCategory, "Exposure")
 }

--- a/internal/pfcp/node.go
+++ b/internal/pfcp/node.go
@@ -3,6 +3,7 @@ package pfcp
 import (
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -17,8 +18,12 @@ const (
 	BUFFQ_LEN = 512
 )
 
+// PDRInfo stores per-PDR state in the session.
 type PDRInfo struct {
 	RelatedURRIDs map[uint32]struct{}
+	// LastIE is the most recent CreatePDR or UpdatePDR IE for this PDR.
+	// It is used to reconstruct UpdatePDR IEs when adding monitoring URRs.
+	LastIE *ie.IE
 }
 
 type URRInfo struct {
@@ -41,6 +46,10 @@ type Sess struct {
 	q        map[uint16]chan []byte // key: PDR_ID
 	qlen     int
 	log      *logrus.Entry
+	// Session metadata extracted from PDRs (set during establishment, read-only after).
+	// Used by Nupf_EventExposure for PDU session matching.
+	UeIpAddr net.IP // UE IPv4 address from PDI UE-IP-Address IE
+	Dnn      string // DNN (Network Instance) from PDI Network-Instance IE
 }
 
 var (
@@ -146,6 +155,9 @@ func (s *Sess) Close() []report.USAReport {
 func (s *Sess) diassociateURR(urrid uint32) []report.USAReport {
 	urrInfo, ok := s.URRIDs[urrid]
 	if !ok {
+		return nil
+	}
+	if urrInfo.removed {
 		return nil
 	}
 
@@ -459,6 +471,18 @@ func (s *Sess) ApplyCreatePDR(plan *forwarder.PDRPlan) {
 
 	s.PDRIDs[plan.PDRID] = &PDRInfo{
 		RelatedURRIDs: urrids,
+		LastIE:        plan.OriginalIE,
+	}
+
+	// Extract session metadata from the PDR's PDI for Nupf_EventExposure matching.
+	if plan.OriginalIE != nil && (s.UeIpAddr == nil || s.Dnn == "") {
+		ueIP, dnn := extractSessionMetadata(plan.OriginalIE)
+		if ueIP != nil && s.UeIpAddr == nil {
+			s.UeIpAddr = ueIP
+		}
+		if dnn != "" && s.Dnn == "" {
+			s.Dnn = dnn
+		}
 	}
 }
 
@@ -485,6 +509,10 @@ func (s *Sess) ApplyUpdatePDR(plan *forwarder.PDRPlan) []report.USAReport {
 		}
 	}
 	pdrInfo.RelatedURRIDs = newUrrids
+	// Update LastIE to the latest modification so we can reconstruct UpdatePDR IEs correctly.
+	if plan.OriginalIE != nil {
+		pdrInfo.LastIE = plan.OriginalIE
+	}
 
 	return usars
 }
@@ -602,6 +630,57 @@ func (s *Sess) CleanupRemovedURRs() {
 	}
 }
 
+// extractSessionMetadata extracts UE IP address and DNN from a PDR IE.
+// These are used by Nupf_EventExposure to match subscriptions to PDU sessions.
+// Returns (ueIP, dnn) — either or both may be nil/empty if not found.
+func extractSessionMetadata(pdrIE *ie.IE) (net.IP, string) {
+	var subIEs []*ie.IE
+	var err error
+
+	switch pdrIE.Type {
+	case ie.CreatePDR:
+		subIEs, err = pdrIE.CreatePDR()
+	case ie.UpdatePDR:
+		subIEs, err = pdrIE.UpdatePDR()
+	default:
+		return nil, ""
+	}
+	if err != nil {
+		return nil, ""
+	}
+
+	for _, sub := range subIEs {
+		if sub.Type != ie.PDI {
+			continue
+		}
+		pdiIEs, err := sub.PDI()
+		if err != nil {
+			continue
+		}
+		var ueIP net.IP
+		var dnn string
+		for _, pdi := range pdiIEs {
+			switch pdi.Type {
+			case ie.UEIPAddress:
+				v, err := pdi.UEIPAddress()
+				if err == nil && v.IPv4Address != nil {
+					ueIP = make(net.IP, len(v.IPv4Address))
+					copy(ueIP, v.IPv4Address)
+				}
+			case ie.NetworkInstance:
+				v, err := pdi.NetworkInstance()
+				if err == nil {
+					dnn = v
+				}
+			}
+		}
+		if ueIP != nil || dnn != "" {
+			return ueIP, dnn
+		}
+	}
+	return nil, ""
+}
+
 type RemoteNode struct {
 	ID     string
 	addr   net.Addr
@@ -671,11 +750,28 @@ func (n *RemoteNode) DeleteSess(lSeid uint64) []report.USAReport {
 }
 
 type LocalNode struct {
+	mu   sync.RWMutex // protects sess and free
 	sess []*Sess
 	free []uint64
 }
 
+// GetAllSessions returns a snapshot of all active sessions.
+// Safe to call from goroutines other than the PfcpServer main loop.
+func (n *LocalNode) GetAllSessions() []*Sess {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	result := make([]*Sess, 0, len(n.sess))
+	for _, s := range n.sess {
+		if s != nil {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 func (n *LocalNode) Reset() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	for _, sess := range n.sess {
 		if sess != nil {
 			sess.Close()
@@ -689,6 +785,9 @@ func (n *LocalNode) Sess(lSeid uint64) (*Sess, error) {
 	if lSeid == 0 {
 		return nil, errors.New("Sess: invalid lSeid:0")
 	}
+
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 
 	// Length as int; compare as uint64 to match lSeid type.
 	sessLen := len(n.sess)
@@ -706,6 +805,8 @@ func (n *LocalNode) Sess(lSeid uint64) (*Sess, error) {
 }
 
 func (n *LocalNode) RemoteSess(rSeid uint64, addr net.Addr) (*Sess, error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	for _, s := range n.sess {
 		if s.RemoteID == rSeid && s.rnode.addr.String() == addr.String() {
 			return s, nil
@@ -725,6 +826,8 @@ func (n *LocalNode) NewSess(rSeid uint64, qlen int) *Sess {
 		q:        make(map[uint16]chan []byte),
 		qlen:     qlen,
 	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	last := len(n.free) - 1
 	if last >= 0 {
 		s.LocalID = n.free[last]
@@ -742,22 +845,27 @@ func (n *LocalNode) DeleteSess(lSeid uint64) ([]report.USAReport, error) {
 		return nil, errors.New("DeleteSess: invalid lSeid:0")
 	}
 
+	n.mu.Lock()
 	// Capacity as int; compare as uint64 to match lSeid type.
 	sessCap := len(n.sess)
 	if lSeid > uint64(sessCap) {
+		n.mu.Unlock()
 		return nil, errors.Errorf("DeleteSess: sess not found (lSeid:%#x)", lSeid)
 	}
 
 	// Safe: 1 <= lSeid <= sessCap ensures valid conversion and index.
 	idx := int(lSeid) - 1
 	if n.sess[idx] == nil {
+		n.mu.Unlock()
 		return nil, errors.Errorf("DeleteSess: sess not found (lSeid:%#x)", lSeid)
 	}
 
-	n.sess[idx].log.Infoln("sess deleted")
-	usars := n.sess[idx].Close()
+	sess := n.sess[idx]
 	n.sess[idx] = nil
 	n.free = append(n.free, lSeid)
+	n.mu.Unlock()
 
+	sess.log.Infoln("sess deleted")
+	usars := sess.Close()
 	return usars, nil
 }

--- a/internal/pfcp/pfcp.go
+++ b/internal/pfcp/pfcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/wmnsk/go-pfcp/ie"
 	"github.com/wmnsk/go-pfcp/message"
 
 	"github.com/free5gc/go-upf/internal/forwarder"
@@ -23,8 +24,21 @@ const (
 	RECEIVE_CHANNEL_LEN       = 512
 	REPORT_CHANNEL_LEN        = 128
 	TRANS_TIMEOUT_CHANNEL_LEN = 64
+	MONITORING_CHANNEL_LEN    = 32
 	MAX_PFCP_MSG_LEN          = 65536
 )
+
+// monitoringReq is a request to add or remove a monitoring URR on a session.
+// Requests are sent through monitoringCh to be processed by the PfcpServer
+// main goroutine, ensuring thread-safe session state modifications.
+type monitoringReq struct {
+	add       bool
+	remove    bool
+	lSeid     uint64
+	urrid     uint32
+	repPeriod time.Duration
+	respCh    chan error
+}
 
 type ReceivePacket struct {
 	RemoteAddr net.Addr
@@ -50,6 +64,7 @@ type PfcpServer struct {
 	rcvCh        chan ReceivePacket
 	srCh         chan report.SessReport
 	trToCh       chan TransactionTimeout
+	monitoringCh chan monitoringReq
 	conn         *net.UDPConn
 	recoveryTime time.Time
 	driver       forwarder.Driver
@@ -70,6 +85,7 @@ func NewPfcpServer(cfg *factory.Config, driver forwarder.Driver) *PfcpServer {
 		rcvCh:        make(chan ReceivePacket, RECEIVE_CHANNEL_LEN),
 		srCh:         make(chan report.SessReport, REPORT_CHANNEL_LEN),
 		trToCh:       make(chan TransactionTimeout, TRANS_TIMEOUT_CHANNEL_LEN),
+		monitoringCh: make(chan monitoringReq, MONITORING_CHANNEL_LEN),
 		recoveryTime: time.Now(),
 		driver:       driver,
 		rnodes:       make(map[string]*RemoteNode),
@@ -77,6 +93,11 @@ func NewPfcpServer(cfg *factory.Config, driver forwarder.Driver) *PfcpServer {
 		rxTrans:      make(map[string]*RxTransaction),
 		log:          logger.PfcpLog.WithField(logger_util.FieldListenAddr, listen),
 	}
+}
+
+// GetLocalNode returns the local PFCP node. Used by Nupf_EventExposure to enumerate sessions.
+func (s *PfcpServer) GetLocalNode() *LocalNode {
+	return &s.lnode
 }
 
 func (s *PfcpServer) main(wg *sync.WaitGroup) {
@@ -116,6 +137,17 @@ func (s *PfcpServer) main(wg *sync.WaitGroup) {
 		case sr := <-s.srCh:
 			s.log.Tracef("receive SessReport from srCh")
 			s.ServeReport(&sr)
+		case req := <-s.monitoringCh:
+			s.log.Tracef("receive monitoring request from monitoringCh")
+			var err error
+			if req.add {
+				err = s.doAddMonitoringURR(req.lSeid, req.urrid, req.repPeriod)
+			} else if req.remove {
+				err = s.doRemoveMonitoringURR(req.lSeid, req.urrid)
+			} else {
+				err = errors.New("invalid monitoring request")
+			}
+			req.respCh <- err
 		case rcvPkt := <-s.rcvCh:
 			s.log.Tracef("receive buf(len=%d) from rcvCh", len(rcvPkt.Buf))
 			if len(rcvPkt.Buf) == 0 {
@@ -428,4 +460,180 @@ func validatePfcpPacketLength(buf []byte) error {
 	}
 
 	return nil
+}
+
+// AddMonitoringURR asynchronously creates a monitoring URR on the specified session.
+// Safe to call from any goroutine; executes in the PfcpServer main loop.
+func (s *PfcpServer) AddMonitoringURR(lSeid uint64, urrid uint32, repPeriod time.Duration) error {
+	respCh := make(chan error, 1)
+	s.monitoringCh <- monitoringReq{add: true, lSeid: lSeid, urrid: urrid, repPeriod: repPeriod, respCh: respCh}
+	return <-respCh
+}
+
+// RemoveMonitoringURR asynchronously removes a monitoring URR from the specified session.
+// Safe to call from any goroutine; executes in the PfcpServer main loop.
+func (s *PfcpServer) RemoveMonitoringURR(lSeid uint64, urrid uint32) error {
+	respCh := make(chan error, 1)
+	s.monitoringCh <- monitoringReq{remove: true, lSeid: lSeid, urrid: urrid, respCh: respCh}
+	return <-respCh
+}
+
+// doAddMonitoringURR creates a URR and links it to all PDRs of the session.
+// Must run in the PfcpServer main goroutine.
+func (s *PfcpServer) doAddMonitoringURR(lSeid uint64, urrid uint32, repPeriod time.Duration) error {
+	sess, err := s.lnode.Sess(lSeid)
+	if err != nil {
+		return err
+	}
+
+	// Build CreateURR IE: VOLUM measurement, PERIO trigger, given period.
+	// ReportingTriggers IE requires at least 2 octets (per go-pfcp and TS 29.244).
+	// Octet 5: PERIO=bit0=0x01; Octet 6: 0x00 (no additional triggers).
+	urrIE := ie.NewCreateURR(
+		ie.NewURRID(urrid),
+		ie.NewMeasurementMethod(0, 1, 0),    // VOLUM=1
+		ie.NewReportingTriggers(0x01, 0x00), // PERIO (2-octet form required)
+		ie.NewMeasurementPeriod(repPeriod),
+	)
+
+	urrPlan, err := sess.ValidateCreateURR(urrIE)
+	if err != nil {
+		return errors.Wrap(err, "ValidateCreateURR")
+	}
+
+	plan := forwarder.NewModificationPlan(lSeid)
+	plan.CreateURRs = []*forwarder.URRPlan{urrPlan}
+
+	// Add URRID to each PDR that has a stored IE so we can reconstruct UpdatePDR.
+	for pdrid, pdrInfo := range sess.PDRIDs {
+		if pdrInfo.LastIE == nil {
+			continue
+		}
+		combined := make(map[uint32]struct{}, len(pdrInfo.RelatedURRIDs)+1)
+		for id := range pdrInfo.RelatedURRIDs {
+			combined[id] = struct{}{}
+		}
+		combined[urrid] = struct{}{}
+
+		updateIE, buildErr := buildUpdatePDRIEForURRSet(pdrInfo.LastIE, pdrid, combined)
+		if buildErr != nil {
+			s.log.Warnf("buildUpdatePDRIEForURRSet pdr[%d]: %v", pdrid, buildErr)
+			continue
+		}
+		p, buildErr := sess.ValidateUpdatePDR(updateIE, plan)
+		if buildErr != nil {
+			s.log.Warnf("ValidateUpdatePDR pdr[%d]: %v", pdrid, buildErr)
+			continue
+		}
+		plan.UpdatePDRs = append(plan.UpdatePDRs, p)
+	}
+
+	_, err = s.driver.ExecuteModificationPlan(plan)
+	if err != nil {
+		return errors.Wrap(err, "ExecuteModificationPlan")
+	}
+
+	sess.ApplyCreateURR(urrPlan)
+	for _, p := range plan.UpdatePDRs {
+		sess.ApplyUpdatePDR(p)
+	}
+	return nil
+}
+
+// doRemoveMonitoringURR removes a monitoring URR from the session and unlinks it from PDRs.
+// Must run in the PfcpServer main goroutine.
+func (s *PfcpServer) doRemoveMonitoringURR(lSeid uint64, urrid uint32) error {
+	sess, err := s.lnode.Sess(lSeid)
+	if err != nil {
+		return err
+	}
+
+	if _, exists := sess.URRIDs[urrid]; !exists {
+		return nil // Already removed
+	}
+
+	plan := forwarder.NewModificationPlan(lSeid)
+	removeURRIE := ie.NewRemoveURR(ie.NewURRID(urrid))
+	urrPlan, err := sess.ValidateRemoveURR(removeURRIE, plan)
+	if err != nil {
+		return errors.Wrap(err, "ValidateRemoveURR")
+	}
+	plan.RemoveURRs = append(plan.RemoveURRs, urrPlan)
+
+	for pdrid, pdrInfo := range sess.PDRIDs {
+		if _, linked := pdrInfo.RelatedURRIDs[urrid]; !linked {
+			continue
+		}
+		if pdrInfo.LastIE == nil {
+			continue
+		}
+		reduced := make(map[uint32]struct{}, len(pdrInfo.RelatedURRIDs))
+		for id := range pdrInfo.RelatedURRIDs {
+			if id != urrid {
+				reduced[id] = struct{}{}
+			}
+		}
+		updateIE, buildErr := buildUpdatePDRIEForURRSet(pdrInfo.LastIE, pdrid, reduced)
+		if buildErr != nil {
+			s.log.Warnf("buildUpdatePDRIEForURRSet pdr[%d]: %v", pdrid, buildErr)
+			continue
+		}
+		p, buildErr := sess.ValidateUpdatePDR(updateIE, plan)
+		if buildErr != nil {
+			s.log.Warnf("ValidateUpdatePDR pdr[%d]: %v", pdrid, buildErr)
+			continue
+		}
+		plan.UpdatePDRs = append(plan.UpdatePDRs, p)
+	}
+
+	_, err = s.driver.ExecuteModificationPlan(plan)
+	if err != nil {
+		return errors.Wrap(err, "ExecuteModificationPlan")
+	}
+
+	sess.ApplyRemoveURR(urrPlan)
+	for _, p := range plan.UpdatePDRs {
+		sess.ApplyUpdatePDR(p)
+	}
+	return nil
+}
+
+// buildUpdatePDRIEForURRSet reconstructs an UpdatePDR IE from a stored CreatePDR/UpdatePDR IE,
+// replacing the URRID sub-IEs with the given set. This is needed because gtp5g kernel driver
+// uses NLM_F_REPLACE which requires all PDR attributes to be resent on update.
+func buildUpdatePDRIEForURRSet(lastIE *ie.IE, pdrid uint16, urrIDs map[uint32]struct{}) (*ie.IE, error) {
+	var subIEs []*ie.IE
+	var err error
+	switch lastIE.Type {
+	case ie.CreatePDR:
+		subIEs, err = lastIE.CreatePDR()
+	case ie.UpdatePDR:
+		subIEs, err = lastIE.UpdatePDR()
+	default:
+		return nil, fmt.Errorf("unknown PDR IE type %d", lastIE.Type)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*ie.IE, 0, len(subIEs)+len(urrIDs))
+	pdridFound := false
+	for _, sub := range subIEs {
+		if sub.Type == ie.URRID {
+			continue // Strip existing URRID IEs; we will re-add below
+		}
+		if sub.Type == ie.PDRID {
+			pdridFound = true
+			out = append(out, ie.NewPDRID(pdrid))
+		} else {
+			out = append(out, sub)
+		}
+	}
+	if !pdridFound {
+		out = append(out, ie.NewPDRID(pdrid))
+	}
+	for id := range urrIDs {
+		out = append(out, ie.NewURRID(id))
+	}
+	return ie.NewUpdatePDR(out...), nil
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime/debug"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/free5gc/go-upf/internal/exposure"
 	"github.com/free5gc/go-upf/internal/forwarder"
 	"github.com/free5gc/go-upf/internal/logger"
 	"github.com/free5gc/go-upf/internal/pfcp"
@@ -17,11 +19,12 @@ import (
 )
 
 type UpfApp struct {
-	ctx        context.Context
-	wg         sync.WaitGroup
-	cfg        *factory.Config
-	driver     forwarder.Driver
-	pfcpServer *pfcp.PfcpServer
+	ctx            context.Context
+	wg             sync.WaitGroup
+	cfg            *factory.Config
+	driver         forwarder.Driver
+	pfcpServer     *pfcp.PfcpServer
+	exposureServer *exposure.Server
 }
 
 func NewApp(cfg *factory.Config) (*UpfApp, error) {
@@ -78,8 +81,26 @@ func (u *UpfApp) Run() error {
 	}
 
 	u.pfcpServer = pfcp.NewPfcpServer(u.cfg, u.driver)
-	u.driver.HandleReport(u.pfcpServer)
+
+	// Create Nupf_EventExposure server
+	exposureAddr := fmt.Sprintf("%s:%d", u.cfg.Pfcp.Addr, factory.UpfEventExposurePort)
+	nodeAdapter := NewNodeAdapter(u.pfcpServer.GetLocalNode())
+	u.exposureServer = exposure.NewServer(exposureAddr, u.pfcpServer, nodeAdapter)
+
+	// Wire report handler: multiplexer routes monitoring reports to exposure server
+	mux := NewReportMultiplexer(u.pfcpServer, u.exposureServer)
+	u.driver.HandleReport(mux)
+
 	u.pfcpServer.Start(&u.wg)
+
+	// Start the exposure HTTP server
+	u.wg.Add(1)
+	go func() {
+		defer u.wg.Done()
+		if err := u.exposureServer.Run(u.ctx); err != nil {
+			logger.MainLog.Warnf("Exposure server stopped: %v", err)
+		}
+	}()
 
 	logger.MainLog.Infoln("UPF started")
 

--- a/pkg/app/mux.go
+++ b/pkg/app/mux.go
@@ -1,0 +1,106 @@
+package app
+
+import (
+	"net"
+
+	"github.com/free5gc/go-upf/internal/exposure"
+	"github.com/free5gc/go-upf/internal/pfcp"
+	"github.com/free5gc/go-upf/internal/report"
+)
+
+// ReportMultiplexer implements report.Handler and multiplexes session reports
+// between the exposure server (monitoring URRs) and the PFCP server (SMF-allocated URRs).
+//
+// The exposure server's HandleReport is called first. If it claims the report as
+// fully consumed (all reports in the SessReport were monitoring URRs), the PFCP
+// server is not notified. Otherwise the PFCP server handles it normally.
+type ReportMultiplexer struct {
+	pfcpServer     *pfcp.PfcpServer
+	exposureServer *exposure.Server
+}
+
+// NewReportMultiplexer creates a multiplexer that routes reports.
+func NewReportMultiplexer(pfcpServer *pfcp.PfcpServer, exposureServer *exposure.Server) *ReportMultiplexer {
+	return &ReportMultiplexer{
+		pfcpServer:     pfcpServer,
+		exposureServer: exposureServer,
+	}
+}
+
+// NotifySessReport implements report.Handler. Reports belonging to monitoring URRs
+// are forwarded to the exposure server; all others go to the PFCP server.
+func (m *ReportMultiplexer) NotifySessReport(sr report.SessReport) {
+	// Split the SessReport: give monitoring URR reports to exposure, rest to pfcp.
+	var exposureReports []report.Report
+	var pfcpReports []report.Report
+
+	for _, r := range sr.Reports {
+		usar, ok := r.(report.USAReport)
+		if ok && isMonitoringURR(usar.URRID) {
+			exposureReports = append(exposureReports, r)
+		} else {
+			pfcpReports = append(pfcpReports, r)
+		}
+	}
+
+	if len(exposureReports) > 0 {
+		m.exposureServer.HandleReport(report.SessReport{
+			SEID:    sr.SEID,
+			Reports: exposureReports,
+		})
+	}
+
+	if len(pfcpReports) > 0 {
+		m.pfcpServer.NotifySessReport(report.SessReport{
+			SEID:    sr.SEID,
+			Reports: pfcpReports,
+		})
+	}
+}
+
+// PopBufPkt implements report.Handler by delegating to the PFCP server.
+func (m *ReportMultiplexer) PopBufPkt(seid uint64, pdrid uint16) ([]byte, bool) {
+	return m.pfcpServer.PopBufPkt(seid, pdrid)
+}
+
+// isMonitoringURR returns true if the URR ID is in the monitoring range.
+const monitoringURRIDBase uint32 = 0xF0000001
+
+func isMonitoringURR(urrid uint32) bool {
+	return urrid >= monitoringURRIDBase
+}
+
+// NodeAdapter wraps pfcp.LocalNode to implement exposure.NodeInterface.
+type NodeAdapter struct {
+	node *pfcp.LocalNode
+}
+
+// NewNodeAdapter creates a NodeAdapter.
+func NewNodeAdapter(node *pfcp.LocalNode) *NodeAdapter {
+	return &NodeAdapter{node: node}
+}
+
+// GetAllSessions returns session info for all active PFCP sessions.
+func (a *NodeAdapter) GetAllSessions() []exposure.SessionInfo {
+	sessions := a.node.GetAllSessions()
+	result := make([]exposure.SessionInfo, 0, len(sessions))
+	for _, s := range sessions {
+		// Copy URR IDs to avoid race conditions (caller may hold no lock)
+		urrIDs := make(map[uint32]struct{}, len(s.URRIDs))
+		for id := range s.URRIDs {
+			urrIDs[id] = struct{}{}
+		}
+		var ueIP net.IP
+		if s.UeIpAddr != nil {
+			ueIP = make(net.IP, len(s.UeIpAddr))
+			copy(ueIP, s.UeIpAddr)
+		}
+		result = append(result, exposure.SessionInfo{
+			LocalID:        s.LocalID,
+			UeIpAddr:       ueIP,
+			Dnn:            s.Dnn,
+			ExistingURRIDs: urrIDs,
+		})
+	}
+	return result
+}

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -22,7 +22,18 @@ type Config struct {
 	Gtpu        *Gtpu     `yaml:"gtpu"        valid:"required"`
 	DnnList     []DnnList `yaml:"dnnList"     valid:"required"`
 	Logger      *Logger   `yaml:"logger"      valid:"required"`
+	// NrfUri is optional. When set, the UPF registers its Nupf_EventExposure service with the NRF.
+	NrfUri string `yaml:"nrfUri" valid:"optional"`
 }
+
+const (
+	// UpfEventExposurePort is the port for the Nupf_EventExposure HTTP server.
+	UpfEventExposurePort = 8090
+	// UpfMonitoringURRIDBase is the starting URR ID for UPF-self-allocated monitoring URRs.
+	// URR IDs above this value are reserved for Event Exposure monitoring, avoiding
+	// collision with SMF-allocated URR IDs which typically start at low values.
+	UpfMonitoringURRIDBase uint32 = 0xF0000001
+)
 
 type Pfcp struct {
 	Addr           string        `yaml:"addr"           valid:"required,host"`


### PR DESCRIPTION
# Nupf_EventExposure PR README

This PR adds a UPF-side implementation of the `Nupf_EventExposure` service defined by 3GPP TS 29.564 Release 17.

It allows an NF service consumer to create, modify, and delete event subscriptions over HTTP, while the UPF translates those subscriptions into PFCP monitoring URRs and sends usage notifications back to the subscriber.

Implementation paths:
- `NFs/upf/internal/exposure/`
- `NFs/upf/internal/pfcp/`
- `NFs/upf/pkg/app/`

## Contents

1. [What This PR Adds](#1-what-this-pr-adds)
2. [External API](#2-external-api)
3. [Internal Interfaces](#3-internal-interfaces)
4. [Data Types](#4-data-types)
5. [Usage](#5-usage)
6. [Testing](#6-testing)
7. [Architecture Summary](#7-architecture-summary)
8. [Design Notes](#8-design-notes)

## 1. What This PR Adds

- HTTP endpoints for create, modify, and delete subscription operations under `/nupf-ee/v1`.
- Notification delivery to the consumer's `eventNotifyUri`.
- PFCP monitoring URR programming for matched PDU sessions.
- Session matching based on UE IP address, `anyUe`, and optional DNN.
- Report routing that separates Exposure monitoring URRs from normal SMF-managed PFCP URRs.
- Thread-safe session snapshot access for the Exposure service.

The current implementation focuses on user data usage measurement events and periodic reporting, which is the path covered by the tests and example workflow below.

## 2. External API

According to TS 29.564 clause 6.1.3, base URI: `{pfcpAddr}:8090/nupf-ee/v1`

### 2.1 Subscription Management API (Subscriptions Collection)

| Method | URI | Description | Spec Section |
|--------|-----|-------------|-------------|
| `POST` | `/ee-subscriptions` | Create new event subscription | TS 29.564 §5.2.2.2.2, §6.1.3.2.3.1 |
| `DELETE` | `/ee-subscriptions/{subscriptionId}` | Cancel subscription | TS 29.564 §5.2.2.2A, §6.1.3.3.3.1 |
| `PATCH` | `/ee-subscriptions/{subscriptionId}` | Modify subscription | TS 29.564 §5.2.2.2.3, §6.1.3.3.3.2 |

#### POST /ee-subscriptions

**Request Body:** `CreateEventSubscription`

**Response 201 Created:** `CreatedEventSubscription` + `Location` header

```
Location: {host}/nupf-ee/v1/ee-subscriptions/{subscriptionId}
```

| HTTP Status | Description |
|-------------|-------------|
| 201 Created | Subscription created successfully |
| 400 Bad Request | JSON parse failed |
| 404 Not Found | No matching PDU session |
| 500 Internal Server Error | All URR creation failed |

#### DELETE /ee-subscriptions/{subscriptionId}

**Response 204 No Content**

| HTTP Status | Description |
|-------------|-------------|
| 204 No Content | Unsubscribed successfully |
| 404 Not Found | `SUBSCRIPTION_NOT_FOUND` |

#### PATCH /ee-subscriptions/{subscriptionId}

**Request Body:** `ModifySubscriptionRequest` (with new `UpfEventSubscription`)

**Response 200 OK:** Updated `UpfEventSubscription`

### 2.2 Event Notification (Outbound Notify)

| Method | URI | Description | Spec Section |
|--------|-----|-------------|-------------|
| `POST` | `{eventNotifyUri}` | Push event notification to consumer | TS 29.564 §5.2.2.3, §6.1.5.2 |

**Request Body:** `NotificationData`  
**Expected Response:** `204 No Content`

---

## 3. Internal Interfaces

### 3.1 `exposure.PfcpInterface`

Defined in `internal/exposure/server.go`, implemented by `pfcp.PfcpServer`.

| Method | Signature | Description |
|--------|-----------|-------------|
| `AddMonitoringURR` | `(lSeid uint64, urrid uint32, repPeriod time.Duration) error` | Asynchronously add monitoring URR to the specified session, via `monitoringCh` in PFCP main loop |
| `RemoveMonitoringURR` | `(lSeid uint64, urrid uint32) error` | Asynchronously remove monitoring URR, same mechanism |

### 3.2 `exposure.NodeInterface`

Defined in `internal/exposure/server.go`, wrapped by `pkg/app.NodeAdapter` for `pfcp.LocalNode`.

| Method | Signature | Description |
|--------|-----------|-------------|
| `GetAllSessions` | `() []SessionInfo` | Get a snapshot of all active PFCP sessions (with UE IP, DNN, existing URRIDs) |

### 3.3 `report.Handler` (`pkg/app.ReportMultiplexer`)

Implemented in `pkg/app/mux.go`, acts as the report receiver for the forwarder driver.

| Method | Description |
|--------|-------------|
| `NotifySessReport(sr report.SessReport)` | Routes USAReports with URRID ≥ `0xF0000001` to ExposureServer, others to PfcpServer |
| `PopBufPkt(seid uint64, pdrid uint16)` | Delegates to PfcpServer |

### 3.4 `pfcp.PfcpServer` Monitoring Methods

Defined in `internal/pfcp/pfcp.go`.

| Method | Visibility | Description |
|--------|------------|-------------|
| `GetLocalNode() *LocalNode` | public | Returns LocalNode for NodeAdapter |
| `AddMonitoringURR(...)` | public | Asynchronously sends `monitoringReq{add:true}` to `monitoringCh` |
| `RemoveMonitoringURR(...)` | public | Asynchronously sends `monitoringReq{remove:true}` to `monitoringCh` |
| `doAddMonitoringURR(...)` | private | In PFCP main loop: creates URR IE, updates each PDR's URRID list |
| `doRemoveMonitoringURR(...)` | private | In PFCP main loop: removes URR, updates each PDR |

### 3.5 `pfcp.Sess` / `pfcp.LocalNode` Fields and Methods

Defined in `internal/pfcp/node.go`.

| Addition | Type | Description |
|----------|------|-------------|
| `PDRInfo.LastIE *ie.IE` | field | Stores last CreatePDR/UpdatePDR raw IE, for reconstructing UpdatePDR (gtp5g NLM_F_REPLACE needs this) |
| `Sess.UeIpAddr net.IP` | field | Extracted from PDR PDI UE-IP-Address IE, for subscription matching |
| `Sess.Dnn string` | field | Extracted from PDR PDI Network-Instance IE |
| `LocalNode.mu sync.RWMutex` | field | Protects sess slice, allows safe concurrent reads from Exposure |
| `LocalNode.GetAllSessions()` | method | RLock-protected session snapshot |
| `extractSessionMetadata(pdrIE)` | function | Reads UE IP and DNN from a PDR IE so Exposure can know which PDU session belongs to which UE |

---

## 4. Data Types

Defined in `internal/exposure/datamodel.go`, per TS 29.564 clause 6.1.6.

### 4.1 Request/Response Types

| Type | Description | Spec Reference |
|------|-------------|---------------|
| `CreateEventSubscription` | POST request body, contains `Subscription UpfEventSubscription` | §6.1.6.2.14 |
| `CreatedEventSubscription` | POST 201 response body, contains `SubscriptionId`, `Subscription`, optional `ReportList` | §6.1.6.2.15 |
| `ModifySubscriptionRequest` | PATCH request body | §6.1.3.3.3.2 |
| `NotificationData` | Notify POST body, contains `NotifCorrId`, `NotificationItems` | §6.1.6.2.2 |

### 4.2 Core Subscription Types

| Type | Key Fields | Description | Spec Reference |
|------|------------|-------------|---------------|
| `UpfEventSubscription` | `EventNotifyUri`, `NotifCorrId`, `EventList`, `EventMode`, `UeIpAddress`, `AnyUe`, `Dnn` | Single subscription resource | §6.1.6.2.11 |
| `UpfEventMode` | `Trigger` (required), `RepPeriod` (seconds), `MaxReports` | Report trigger mode | §6.1.6.2.12 |
| `UpfEvent` | `Type` (required), `ImmediateFlag`, `MeasurementType` | Single event description | §6.1.6.2.13 |

### 4.3 Measurement Data Types

| Type | Description | Spec Reference |
|------|-------------|---------------|
| `NotificationItem` | Single event notification item, includes `SourceUeIpAddress`, `TimeStamp`, `EventType`, `UsageData` | §6.1.6.2.3 |
| `UserDataUsageMeasurements` | Usage measurement result, includes `VolumeMeasurement`, `ThroughputMeasurement` | §6.1.6.2.5 |
| `VolumeMeasurement` | UL/DL/Total bytes, packet count | §6.1.6.2.6 |
| `ThroughputMeasurement` | UL/DL throughput (bit/s) | §6.1.6.2.7 |

### 4.4 Enum Types

| Type | Possible Values | Spec Reference |
|------|-----------------|---------------|
| `EventType` | `USER_DATA_USAGE_MEASURES`, `USER_DATA_USAGE_TRENDS`, `QOS_MONITORING`, `TSC_MNGT_INFO` | §6.1.6.3.3 |
| `UpfEventTrigger` | `ONE_TIME`, `PERIODIC` | §6.1.6.3.4 |
| `MeasurementType` | `VOLUME`, `THROUGHPUT` | §6.1.6.3.5 |
| `GranularityOfMeasurement` | `PER_UE`, `PER_FLOW`, `PER_APP_ID`, `AGGREGATE` | §6.1.6.3.6 |

### 4.5 Internal Types

| Type | Defined In | Description |
|------|------------|-------------|
| `exposure.SessionInfo` | `server.go` | Session snapshot: `LocalID uint64`, `UeIpAddr net.IP`, `Dnn string`, `ExistingURRIDs map[uint32]struct{}` |
| `pfcp.monitoringReq` | `pfcp.go` | Monitoring URR request: `add/remove bool`, `lSeid`, `urrid`, `repPeriod`, `respCh chan error` |

---

## 5. Usage

### 5.1 Startup

The Exposure service **starts automatically** with UPF, listening on `{pfcp.addr}:8090`. No extra config needed.

To register the `nupf-ee` service to NRF, add to `config/upfcfg.yaml`:

```yaml
nrfUri: "http://127.0.0.10:8000"
```

**Prerequisite:** There must be at least one active PDU session before creating a subscription. The UPF discovers the target UE via the `ueIpAddress` field — this is the IP address assigned to the UE at PDU session establishment (e.g., `10.60.0.1` from the `10.60.0.0/24` pool). You can find it in the UPF log or via the free5GC Webconsole.

### 5.2 Start Local Test Notification Receiver

Before creating a subscription, start the bundled notification receiver so the UPF has a reachable endpoint to POST to:

```bash
python3 EventExposure_upf/receiver.py
# Mock Notification Receiver listening on http://127.0.0.1:9000
# Accepts any POST path — use e.g. http://127.0.0.1:9000/notify as eventNotifyUri
```

The receiver accepts **any POST path**, responds with `204 No Content`, and prints each notification to stdout. Keep this running in a separate terminal.

Use a reachable IP-based URI in test environments so periodic notifications do not fail because of DNS resolution issues.

### 5.3 Create Subscription (Subscribe)

```bash
curl -X POST http://127.0.0.8:8090/nupf-ee/v1/ee-subscriptions \
  -H "Content-Type: application/json" \
  -d '{
    "subscription": {
      "eventNotifyUri": "http://127.0.0.1:9000/notify",
      "notifyCorrelationId": "corr-001",
      "eventList": [
        {
          "type": "USER_DATA_USAGE_MEASURES",
          "measurementTypes": ["VOLUME"]
        }
      ],
      "eventReportingMode": {
        "trigger": "PERIODIC",
        "repPeriod": 30
      },
      "nfId": "a1b2c3d4-...",
      "ueIpAddress": "10.60.0.1"
    }
  }'
```

**Success Response (201):**

```json
{
  "subscriptionId": "550e8400-e29b-41d4-a716-446655440000",
  "subscription": { "..." }
}
```

`Location` header: `http://127.0.0.8:8090/nupf-ee/v1/ee-subscriptions/550e8400-...`

### 5.4 Cancel Subscription (Unsubscribe)

```bash
curl -X DELETE http://127.0.0.8:8090/nupf-ee/v1/ee-subscriptions/550e8400-e29b-41d4-a716-446655440000
# HTTP 204 No Content
```

### 5.5 Modify Subscription (Modify)

```bash
curl -X PATCH http://127.0.0.8:8090/nupf-ee/v1/ee-subscriptions/550e8400-... \
  -H "Content-Type: application/json" \
  -d '{ "subscription": { "eventNotifyUri": "http://new-endpoint/notify", "..." } }'
# HTTP 200 OK
```

### 5.6 Receive Notification

The subscriber's `eventNotifyUri` endpoint will receive POST requests in the following format:

```json
{
  "notifyCorrelationId": "corr-001",
  "notificationItems": [
    {
      "eventType": "USER_DATA_USAGE_MEASURES",
      "sourceUeIpAddress": "10.60.0.1",
      "timeStamp": "2026-04-28T10:00:00Z",
      "usageData": [
        {
          "volumeMeasurement": {
            "totalVolume": 1048576,
            "ulVolume": 524288,
            "dlVolume": 524288
          }
        }
      ]
    }
  ]
}
```

**Subscriber should respond with `204 No Content`.**

When using `receiver.py`, each notification is printed to the terminal:

```
--- [NOTIFICATION] POST /notify ---
{
  "notifyCorrelationId": "corr-001",
  "notificationItems": [ ... ]
}
---------------------------------------
```

---

### 5.7 Complete End-to-End Test Workflow

After a UE has established a PDU session (UE IP: `10.60.0.1`), the full test flow is:

**Step 1 — Start the notification receiver** (separate terminal)

```bash
python3 EventExposure_upf/receiver.py
```

**Step 2 — Create a subscription**

```bash
SUB=$(curl -s -X POST http://127.0.0.8:8090/nupf-ee/v1/ee-subscriptions \
  -H "Content-Type: application/json" \
  -d '{
    "subscription": {
      "eventNotifyUri": "http://127.0.0.1:9000/notify",
      "notifyCorrelationId": "test-001",
      "eventList": [{"type": "USER_DATA_USAGE_MEASURES", "measurementTypes": ["VOLUME"]}],
      "eventReportingMode": {"trigger": "PERIODIC", "repPeriod": 10},
      "ueIpAddress": "10.60.0.1"
    }
  }')
echo $SUB
SUB_ID=$(echo $SUB | python3 -c "import sys,json; print(json.load(sys.stdin)['subscriptionId'])")
echo "Subscription ID: $SUB_ID"
```

**Step 3 — Generate traffic through the UE** (ping or iperf via the UE interface)

```bash
# From UE side or uesimtun0:
ping -c 20 8.8.8.8 -I uesimtun0
```

**Step 4 — Wait for periodic notifications** (every 10 seconds)

The receiver terminal will print volume measurements. Verify that `ulVolume` / `dlVolume` increase as traffic flows.

**Step 5 — Delete the subscription**

```bash
curl -X DELETE http://127.0.0.8:8090/nupf-ee/v1/ee-subscriptions/$SUB_ID
# HTTP 204 No Content
```

Notifications stop after deletion.

---

## 6. Testing

Test file: `internal/exposure/server_test.go`

### 6.1 Test List

| Test Function | Scenario | Key Verification |
|---------------|----------|-----------------|
| `TestCreateSubscription_MatchByUeIP` | Match single session by UE IP | Correctly calls `AddMonitoringURR`, lSeid/repPeriod correct |
| `TestCreateSubscription_AnyUe` | `anyUe=true`, matches all sessions | `AddMonitoringURR` called twice (for two sessions) |
| `TestCreateSubscription_NoMatch` | UE IP not found in any session | Returns 404, does not call `AddMonitoringURR` |
| `TestDeleteSubscription` | Normal unsubscribe | `RemoveMonitoringURR` called, lSeid correct |
| `TestDeleteSubscription_NotFound` | Delete non-existent subscription | Returns 404 |
| `TestHandleReport_ConsumesMonitoringURR` | Simulate PFCP USAReport | Triggers HTTP POST to `eventNotifyUri`, verifies notification delivery |
| `TestHTTPCreateSubscription` | POST /ee-subscriptions HTTP route | Returns 201, Location header non-empty, response body contains subscriptionId |
| `TestHTTPDeleteSubscription` | DELETE /ee-subscriptions/{id} HTTP route | Returns 204 |

### 6.2 Run Tests

```bash
cd NFs/upf
go test ./internal/exposure/... -v
```

**Sample Output:**
```
=== RUN   TestCreateSubscription_MatchByUeIP
--- PASS: TestCreateSubscription_MatchByUeIP (0.00s)
=== RUN   TestCreateSubscription_AnyUe
--- PASS: TestCreateSubscription_AnyUe (0.00s)
=== RUN   TestCreateSubscription_NoMatch
--- PASS: TestCreateSubscription_NoMatch (0.00s)
=== RUN   TestDeleteSubscription
--- PASS: TestDeleteSubscription (0.00s)
=== RUN   TestDeleteSubscription_NotFound
--- PASS: TestDeleteSubscription_NotFound (0.00s)
=== RUN   TestHandleReport_ConsumesMonitoringURR
--- PASS: TestHandleReport_ConsumesMonitoringURR (0.01s)
=== RUN   TestHTTPCreateSubscription
--- PASS: TestHTTPCreateSubscription (0.00s)
=== RUN   TestHTTPDeleteSubscription
--- PASS: TestHTTPDeleteSubscription (0.00s)
PASS
ok  github.com/free5gc/go-upf/internal/exposure
```

### 6.3 Full Module Test

```bash
cd NFs/upf
go test ./...
# Expected failures: buffnetlink (needs GTP kernel module), pkg/app (needs GTP kernel module)
# These are environment limitations, not code errors
```

```bash
go vet ./...      # Static analysis, no output = pass
```

---

## 7. Architecture Summary

### 7.1 Subscription Creation Flow

```mermaid
sequenceDiagram
    participant C as NF Service Consumer (NWDAF/SMF)
    participant E as ExposureServer (HTTP :8090)
    participant P as PfcpServer (main goroutine)
    participant K as Kernel / gtp5g

    C->>E: POST /nupf-ee/v1/ee-subscriptions {ueIpAddress: "10.60.0.1", trigger: PERIODIC, repPeriod: 30}
  E->>E: Parse request and find matching PDU session by UE IP / anyUe
    alt Found matching session
    E->>E: Allocate a monitoring URRID (0xF0000001+)
    E->>P: AddMonitoringURR(lSeid, urrid, 30s)
    P->>P: Queue request to monitoringCh
    P->>K: Update URR and linked PDRs
    K-->>P: Success
    P-->>E: Return result
    E->>E: Save subscription record
    E-->>C: 201 Created
    else No matching session
        E-->>C: 404 Not Found
    end
```

### 7.2 Periodic Report and Notification Flow

```mermaid
sequenceDiagram
    participant K as Kernel / gtp5g (perio timer)
    participant D as forwarder.Driver
    participant M as ReportMultiplexer
    participant E as ExposureServer
    participant P as PfcpServer
    participant C as NF Service Consumer

    K->>D: URR PERIO triggered, report USAReport{URRID=0xF0000001, volume=...}
    D->>M: NotifySessReport(SessReport{SEID=1, Reports=[USAReport]})
    M->>M: Check URRID >= 0xF0000001?
    alt Monitoring URR (Exposure)
        M->>E: HandleReport(SessReport with monitoring reports only)
        E->>E: Find subscription: sessionURRs[SEID] == URRID?
        E->>E: buildNotificationItem(): fill UE IP, timestamp, volume data
        E->>C: POST {eventNotifyUri} body: NotificationData
        C-->>E: 204 No Content
    else SMF URR (normal PFCP report)
        M->>P: NotifySessReport(SessReport with SMF reports only)
        P->>P: ServeReport() normal handling
    end
```

### 7.3 Unsubscribe Flow

```mermaid
sequenceDiagram
    participant C as NF Service Consumer
    participant E as ExposureServer
    participant P as PfcpServer
    participant K as Kernel / gtp5g

    C->>E: DELETE /nupf-ee/v1/ee-subscriptions/{subID}
    E->>E: Look up saved {lSeid -> urrid}
    loop For each session's monitoring URR
        E->>P: RemoveMonitoringURR(lSeid, urrid)
        P->>P: Queue request to monitoringCh
        P->>K: Remove URR and unlink it from PDRs
        K-->>P: Success
        P-->>E: Return result
    end
    E-->>C: 204 No Content
```

### 7.4 Architecture Diagram

```mermaid
graph TB
  Consumer[NWDAF / Event Consumer]
  Exposure[ExposureServer\nHTTP :8090]
  Node[LocalNode\nGetAllSessions]
  PFCP[PfcpServer\nmonitoringCh]
  Kernel[gtp5g / Kernel]
  Mux[ReportMultiplexer]
  SMF[SMF]

  Consumer -->|Create / Modify / Delete subscription| Exposure
  Exposure -->|Read active sessions| Node
  Exposure -->|AddMonitoringURR / RemoveMonitoringURR| PFCP
  PFCP -->|Program URR / PDR| Kernel
  Kernel -->|Periodic usage reports| Mux
  Mux -->|Monitoring URRs| Exposure
  Mux -->|Normal SMF URRs| PFCP
  PFCP -->|PFCP Session Report| SMF
  Exposure -->|HTTP notification| Consumer

  style Exposure fill:#e8f5e9,stroke:#4caf50
  style PFCP fill:#fff3e0,stroke:#ff9800
  style Mux fill:#e3f2fd,stroke:#2196f3
```

---

## 8. Design Notes

| Issue | Decision | Reason |
|-------|----------|--------|
| gtp5g PDR update needs all attributes | Store `PDRInfo.LastIE`, rebuild UpdatePDR IE | gtp5g uses `NLM_F_REPLACE` flag, does not support delta update |
| Multi-goroutine session access | `AddMonitoringURR` via `monitoringCh` in PFCP main loop | PFCP session state can only be modified in main loop, avoids data race |
| URRID does not conflict with SMF | Use high range `0xF0000001+` | SMF usually starts from 1; uint32 range is sufficient |
| Notification does not block PFCP main loop | `HandleReport` outside goroutine, HTTP POST is sync but only in report handler goroutine | PFCP main loop does not call HandleReport directly |
