### PR TITLE
Fix/nil when processing session report response

### DIFF
--- a/internal/pfcp/node.go
+++ b/internal/pfcp/node.go
@@ -706,8 +706,16 @@ func (n *LocalNode) Sess(lSeid uint64) (*Sess, error) {
 }
 
 func (n *LocalNode) RemoteSess(rSeid uint64, addr net.Addr) (*Sess, error) {
+	addrString := ""
+	if addr != nil {
+		addrString = addr.String()
+	}
+
 	for _, s := range n.sess {
-		if s.RemoteID == rSeid && s.rnode.addr.String() == addr.String() {
+		if s == nil || s.rnode == nil || s.rnode.addr == nil {
+			continue
+		}
+		if s.RemoteID == rSeid && s.rnode.addr.String() == addrString {
 			return s, nil
 		}
 	}

--- a/internal/pfcp/node_test.go
+++ b/internal/pfcp/node_test.go
@@ -1,6 +1,7 @@
 package pfcp
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -236,5 +237,28 @@ func TestLocalNode(t *testing.T) {
 		recycleLocalID := 1
 		assert.Equal(t, uint64(recycleLocalID), sess.LocalID)
 		assert.Equal(t, uint64(10), sess.RemoteID)
+	})
+
+	t.Run("remote sess skips deleted local slots", func(t *testing.T) {
+		addr := &net.UDPAddr{IP: net.IPv4(10, 100, 200, 5), Port: 8805}
+		lnode := &LocalNode{}
+		rnode := NewRemoteNode(
+			"smf1",
+			addr,
+			lnode,
+			forwarder.Empty{},
+			logger.PfcpLog.WithField(logger_util.FieldControlPlaneNodeID, "smf1"),
+		)
+
+		deletedSess := rnode.NewSess(0x1efcd)
+		activeSess := rnode.NewSess(0x1efce)
+		rnode.DeleteSess(deletedSess.LocalID)
+
+		sess, err := lnode.RemoteSess(activeSess.RemoteID, addr)
+		assert.NoError(t, err)
+		assert.Equal(t, activeSess.LocalID, sess.LocalID)
+
+		_, err = lnode.RemoteSess(deletedSess.RemoteID, addr)
+		assert.Error(t, err)
 	})
 }

--- a/internal/pfcp/session.go
+++ b/internal/pfcp/session.go
@@ -614,7 +614,21 @@ func (s *PfcpServer) handleSessionReportResponse(
 
 	s.log.Debugf("seid: %#x\n", rsp.SEID())
 	if rsp.Header.SEID == 0 {
-		s.log.Warnf("rsp SEID is 0; no this session on remote; delete it on local")
+		if rsp.Cause == nil {
+			s.log.Errorf("rsp SEID is 0 without Cause IE")
+			return
+		}
+		cause, err := rsp.Cause.Cause()
+		if err != nil {
+			s.log.Errorf("rsp SEID is 0 with invalid Cause IE: %v", err)
+			return
+		}
+		if cause != ie.CauseSessionContextNotFound {
+			s.log.Errorf("rsp SEID is 0 with unexpected cause[%d]", cause)
+			return
+		}
+
+		s.log.Warnf("rsp SEID is 0 and cause is Session context not found; delete it on local")
 		sess, err := s.lnode.RemoteSess(req.SEID(), addr)
 		if err != nil {
 			s.log.Errorln(err)

--- a/internal/pfcp/session_test.go
+++ b/internal/pfcp/session_test.go
@@ -1,0 +1,68 @@
+package pfcp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
+
+	"github.com/free5gc/go-upf/internal/forwarder"
+	"github.com/free5gc/go-upf/internal/logger"
+	logger_util "github.com/free5gc/util/logger"
+)
+
+func TestHandleSessionReportResponseSEIDZeroCause(t *testing.T) {
+	addr := &net.UDPAddr{IP: net.IPv4(10, 100, 200, 5), Port: 8805}
+	newServerWithSession := func(remoteID uint64) (*PfcpServer, *Sess) {
+		s := &PfcpServer{
+			log: logger.PfcpLog.WithField(logger_util.FieldListenAddr, "upf.free5gc.org:8805"),
+		}
+		rnode := NewRemoteNode(
+			"10.100.200.5",
+			addr,
+			&s.lnode,
+			forwarder.Empty{},
+			s.log.WithField(logger_util.FieldControlPlaneNodeID, "10.100.200.5"),
+		)
+		return s, rnode.NewSess(remoteID)
+	}
+
+	t.Run("keeps local session when cause is not session context not found", func(t *testing.T) {
+		s, sess := newServerWithSession(0x1efce)
+		req := message.NewSessionReportRequest(0, 0, sess.RemoteID, 1, 0)
+		rsp := message.NewSessionReportResponse(
+			0,
+			0,
+			0,
+			1,
+			0,
+			ie.NewCause(ie.CauseRequestAccepted),
+		)
+
+		s.handleSessionReportResponse(rsp, addr, req)
+
+		got, err := s.lnode.Sess(sess.LocalID)
+		assert.NoError(t, err)
+		assert.Equal(t, sess.LocalID, got.LocalID)
+	})
+
+	t.Run("deletes local session when cause is session context not found", func(t *testing.T) {
+		s, sess := newServerWithSession(0x1efce)
+		req := message.NewSessionReportRequest(0, 0, sess.RemoteID, 1, 0)
+		rsp := message.NewSessionReportResponse(
+			0,
+			0,
+			0,
+			1,
+			0,
+			ie.NewCause(ie.CauseSessionContextNotFound),
+		)
+
+		s.handleSessionReportResponse(rsp, addr, req)
+
+		_, err := s.lnode.Sess(sess.LocalID)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
This PR fixes a UPF crash in PFCP Session Report Response handling and tightens the local-session deletion condition for SEID=0 responses.

**Root Cause**
LocalNode.DeleteSess() removes a session by setting the corresponding n.sess[idx] entry to nil, leaving that slot available for later reuse by the free-list.

After that, when UPF receives a SessionReportResponse with rsp.SEID == 0, handleSessionReportResponse() falls back to the original request SEID and calls:
```
s.lnode.RemoteSess(req.SEID(), addr)
```
to find the local session by the remote CP-SEID.

Previously, RemoteSess() iterated over n.sess and directly accessed:
```
s.RemoteID
```
without checking whether s was nil. If a deleted session slot appeared before a still-valid session, UPF dereferenced the nil slot and crashed before it could reach the valid session.

**Changes**
* Hardened LocalNode.RemoteSess() to skip:
* * nil session slots
* * sessions without a remote node
* * sessions without a remote address
* Updated handleSessionReportResponse() so local session deletion on SEID=0 only happens when the response Cause IE is:
* * present
* * valid
* * equal to ie.CauseSessionContextNotFound
* For SEID=0 responses with missing, invalid, or unexpected Cause IE, UPF now logs an error and keeps the local session.
