### PR TITLE
fix: reject PFCP session modification when rule execution fails

### DIFF
--- a/internal/forwarder/driver.go
+++ b/internal/forwarder/driver.go
@@ -45,7 +45,8 @@ type Driver interface {
 	BuildRemoveBARPlan(lSeid uint64, req *ie.IE) (*BARPlan, error)
 
 	// ExecuteModificationPlan executes all operations in the plan
-	// Uses best-effort execution: continues on failure, logs errors
+	// Uses fail-fast: rolls back the rules created by this plan and returns
+	// an error on first failure
 	ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResult, error)
 
 	// ExecuteEstablishmentPlan executes Create operations for session establishment

--- a/internal/forwarder/driver.go
+++ b/internal/forwarder/driver.go
@@ -44,9 +44,10 @@ type Driver interface {
 	BuildUpdateBARPlan(lSeid uint64, req *ie.IE) (*BARPlan, error)
 	BuildRemoveBARPlan(lSeid uint64, req *ie.IE) (*BARPlan, error)
 
-	// ExecuteModificationPlan executes all operations in the plan
-	// Uses fail-fast: rolls back the rules created by this plan and returns
-	// an error on first failure
+	// ExecuteModificationPlan executes all operations in the plan.
+	// Create operations are fail-fast: on failure the rules created by this plan
+	// are rolled back and an error is returned. Remove/Update/Query operations
+	// are best-effort: failures are logged and execution continues.
 	ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResult, error)
 
 	// ExecuteEstablishmentPlan executes Create operations for session establishment

--- a/internal/forwarder/gtp5g.go
+++ b/internal/forwarder/gtp5g.go
@@ -1736,10 +1736,10 @@ func (g *Gtp5g) rollbackCreatedRules(plan *ModificationPlan, created *createdRul
 		}
 	}
 	for _, p := range created.urrs {
-		g.ps.DelPeriodReportTimer(plan.SEID, p.URRID)
 		if _, err := gtp5gnl.RemoveURROID(g.client, g.link.link, p.OID); err != nil {
 			g.log.Errorf("Rollback: RemoveURR[%#x] failed: %v", p.URRID, err)
 		}
+		g.ps.DelPeriodReportTimer(plan.SEID, p.URRID)
 	}
 	for _, p := range created.qers {
 		if err := gtp5gnl.RemoveQEROID(g.client, g.link.link, p.OID); err != nil {
@@ -1754,11 +1754,17 @@ func (g *Gtp5g) rollbackCreatedRules(plan *ModificationPlan, created *createdRul
 }
 
 // ExecuteModificationPlan executes all operations in the plan.
-// Uses fail-fast semantics: on the first failure it rolls back the rules created
-// by this plan and returns an error, so that the caller can reject the request
-// instead of reporting success for rules that were never installed.
-// Remove/Update operations already executed cannot be rolled back; they are
-// applied only after all Create operations succeeded.
+//
+// Create operations use fail-fast semantics: on the first Create failure the
+// rules already created by this plan are rolled back and an error is returned,
+// so the caller can reject the request instead of reporting success for rules
+// that were never installed. Because Create operations run before any Remove or
+// Update, the rollback at that point is always complete.
+//
+// Remove/Update/Query operations use best-effort semantics: failures are logged
+// and execution continues. These operations are not rolled back (a removed or
+// updated rule cannot be restored), and callers that build Remove-only plans
+// (e.g. session close in node.go) rely on this to clean up as much as possible.
 func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResult, error) {
 	result := NewExecutionResult()
 	created := &createdRules{}
@@ -1807,17 +1813,18 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 		created.pdrs = append(created.pdrs, p)
 	}
 
+	// Remove/Update/Query operations are best-effort: all Create operations have
+	// already succeeded at this point, so a later failure here is logged and
+	// execution continues instead of rolling back the created rules.
 	for _, p := range plan.RemovePDRs {
 		if err := gtp5gnl.RemovePDROID(g.client, g.link.link, p.OID); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: RemovePDR[%#x] failed", p.PDRID)
+			g.log.Errorf("ExecuteModificationPlan: RemovePDR[%#x] failed: %v", p.PDRID, err)
 		}
 	}
 
 	for _, p := range plan.RemoveBARs {
 		if err := gtp5gnl.RemoveBAROID(g.client, g.link.link, p.OID); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: RemoveBAR[%#x] failed", p.BARID)
+			g.log.Errorf("ExecuteModificationPlan: RemoveBAR[%#x] failed: %v", p.BARID, err)
 		}
 	}
 
@@ -1825,8 +1832,7 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 		g.ps.DelPeriodReportTimer(plan.SEID, p.URRID)
 		rs, err := gtp5gnl.RemoveURROID(g.client, g.link.link, p.OID)
 		if err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: RemoveURR[%#x] failed", p.URRID)
+			g.log.Errorf("ExecuteModificationPlan: RemoveURR[%#x] failed: %v", p.URRID, err)
 		}
 		for _, r := range rs {
 			result.USAReports = append(result.USAReports, g.convertUSAReport(r))
@@ -1835,22 +1841,19 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 
 	for _, p := range plan.RemoveQERs {
 		if err := gtp5gnl.RemoveQEROID(g.client, g.link.link, p.OID); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: RemoveQER[%#x] failed", p.QERID)
+			g.log.Errorf("ExecuteModificationPlan: RemoveQER[%#x] failed: %v", p.QERID, err)
 		}
 	}
 
 	for _, p := range plan.RemoveFARs {
 		if err := gtp5gnl.RemoveFAROID(g.client, g.link.link, p.OID); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: RemoveFAR[%#x] failed", p.FARID)
+			g.log.Errorf("ExecuteModificationPlan: RemoveFAR[%#x] failed: %v", p.FARID, err)
 		}
 	}
 
 	for _, p := range plan.UpdateFARs {
 		if err := gtp5gnl.UpdateFAROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: UpdateFAR[%#x] failed", p.FARID)
+			g.log.Errorf("ExecuteModificationPlan: UpdateFAR[%#x] failed: %v", p.FARID, err)
 		}
 
 		if p.ApplyAction != nil {
@@ -1860,16 +1863,14 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 
 	for _, p := range plan.UpdateQERs {
 		if err := gtp5gnl.UpdateQEROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: UpdateQER[%#x] failed", p.QERID)
+			g.log.Errorf("ExecuteModificationPlan: UpdateQER[%#x] failed: %v", p.QERID, err)
 		}
 	}
 
 	for _, p := range plan.UpdateURRs {
 		rs, err := gtp5gnl.UpdateURROID(g.client, g.link.link, p.OID, p.Attrs)
 		if err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: UpdateURR[%#x] failed", p.URRID)
+			g.log.Errorf("ExecuteModificationPlan: UpdateURR[%#x] failed: %v", p.URRID, err)
 		}
 		for _, r := range rs {
 			result.USAReports = append(result.USAReports, g.convertUSAReport(r))
@@ -1878,15 +1879,13 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 
 	for _, p := range plan.UpdateBARs {
 		if err := gtp5gnl.UpdateBAROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: UpdateBAR[%#x] failed", p.BARID)
+			g.log.Errorf("ExecuteModificationPlan: UpdateBAR[%#x] failed: %v", p.BARID, err)
 		}
 	}
 
 	for _, p := range plan.UpdatePDRs {
 		if err := gtp5gnl.UpdatePDROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.rollbackCreatedRules(plan, created)
-			return nil, errors.Wrapf(err, "ModificationPlan: UpdatePDR[%#x] failed", p.PDRID)
+			g.log.Errorf("ExecuteModificationPlan: UpdatePDR[%#x] failed: %v", p.PDRID, err)
 		}
 	}
 

--- a/internal/forwarder/gtp5g.go
+++ b/internal/forwarder/gtp5g.go
@@ -1711,21 +1711,72 @@ func (g *Gtp5g) BuildRemoveBARPlan(lSeid uint64, req *ie.IE) (*BARPlan, error) {
 	}, nil
 }
 
-// ExecuteModificationPlan executes all operations in the plan
-// Uses best-effort execution: continues on failure, logs errors
+// createdRules records the rules this plan has already created in gtp5g,
+// so that they can be rolled back if a later operation of the same plan fails.
+type createdRules struct {
+	fars []*FARPlan
+	qers []*QERPlan
+	urrs []*URRPlan
+	bars []*BARPlan
+	pdrs []*PDRPlan
+}
+
+// rollbackCreatedRules removes the rules created by the current plan, in reverse
+// dependency order. Only rules whose creation succeeded are removed, so a rule
+// that already existed before the plan is never touched.
+func (g *Gtp5g) rollbackCreatedRules(plan *ModificationPlan, created *createdRules) {
+	for _, p := range created.pdrs {
+		if err := gtp5gnl.RemovePDROID(g.client, g.link.link, p.OID); err != nil {
+			g.log.Errorf("Rollback: RemovePDR[%#x] failed: %v", p.PDRID, err)
+		}
+	}
+	for _, p := range created.bars {
+		if err := gtp5gnl.RemoveBAROID(g.client, g.link.link, p.OID); err != nil {
+			g.log.Errorf("Rollback: RemoveBAR[%#x] failed: %v", p.BARID, err)
+		}
+	}
+	for _, p := range created.urrs {
+		g.ps.DelPeriodReportTimer(plan.SEID, p.URRID)
+		if _, err := gtp5gnl.RemoveURROID(g.client, g.link.link, p.OID); err != nil {
+			g.log.Errorf("Rollback: RemoveURR[%#x] failed: %v", p.URRID, err)
+		}
+	}
+	for _, p := range created.qers {
+		if err := gtp5gnl.RemoveQEROID(g.client, g.link.link, p.OID); err != nil {
+			g.log.Errorf("Rollback: RemoveQER[%#x] failed: %v", p.QERID, err)
+		}
+	}
+	for _, p := range created.fars {
+		if err := gtp5gnl.RemoveFAROID(g.client, g.link.link, p.OID); err != nil {
+			g.log.Errorf("Rollback: RemoveFAR[%#x] failed: %v", p.FARID, err)
+		}
+	}
+}
+
+// ExecuteModificationPlan executes all operations in the plan.
+// Uses fail-fast semantics: on the first failure it rolls back the rules created
+// by this plan and returns an error, so that the caller can reject the request
+// instead of reporting success for rules that were never installed.
+// Remove/Update operations already executed cannot be rolled back; they are
+// applied only after all Create operations succeeded.
 func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResult, error) {
 	result := NewExecutionResult()
+	created := &createdRules{}
 
 	for _, p := range plan.CreateFARs {
 		if err := gtp5gnl.CreateFAROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: CreateFAR[%#x] failed: %v", p.FARID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: CreateFAR[%#x] failed", p.FARID)
 		}
+		created.fars = append(created.fars, p)
 	}
 
 	for _, p := range plan.CreateQERs {
 		if err := gtp5gnl.CreateQEROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: CreateQER[%#x] failed: %v", p.QERID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: CreateQER[%#x] failed", p.QERID)
 		}
+		created.qers = append(created.qers, p)
 	}
 
 	for _, p := range plan.CreateURRs {
@@ -1733,31 +1784,40 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 			g.ps.AddPeriodReportTimer(plan.SEID, p.URRID, p.MeasurePeriod)
 		}
 		if err := gtp5gnl.CreateURROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: CreateURR[%#x] failed: %v", p.URRID, err)
+			g.ps.DelPeriodReportTimer(plan.SEID, p.URRID)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: CreateURR[%#x] failed", p.URRID)
 		}
+		created.urrs = append(created.urrs, p)
 	}
 
 	for _, p := range plan.CreateBARs {
 		if err := gtp5gnl.CreateBAROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: CreateBAR[%#x] failed: %v", p.BARID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: CreateBAR[%#x] failed", p.BARID)
 		}
+		created.bars = append(created.bars, p)
 	}
 
 	for _, p := range plan.CreatePDRs {
 		if err := gtp5gnl.CreatePDROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: CreatePDR[%#x] failed: %v", p.PDRID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: CreatePDR[%#x] failed", p.PDRID)
 		}
+		created.pdrs = append(created.pdrs, p)
 	}
 
 	for _, p := range plan.RemovePDRs {
 		if err := gtp5gnl.RemovePDROID(g.client, g.link.link, p.OID); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: RemovePDR[%#x] failed: %v", p.PDRID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: RemovePDR[%#x] failed", p.PDRID)
 		}
 	}
 
 	for _, p := range plan.RemoveBARs {
 		if err := gtp5gnl.RemoveBAROID(g.client, g.link.link, p.OID); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: RemoveBAR[%#x] failed: %v", p.BARID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: RemoveBAR[%#x] failed", p.BARID)
 		}
 	}
 
@@ -1765,7 +1825,8 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 		g.ps.DelPeriodReportTimer(plan.SEID, p.URRID)
 		rs, err := gtp5gnl.RemoveURROID(g.client, g.link.link, p.OID)
 		if err != nil {
-			g.log.Errorf("ExecuteModificationPlan: RemoveURR[%#x] failed: %v", p.URRID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: RemoveURR[%#x] failed", p.URRID)
 		}
 		for _, r := range rs {
 			result.USAReports = append(result.USAReports, g.convertUSAReport(r))
@@ -1774,19 +1835,22 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 
 	for _, p := range plan.RemoveQERs {
 		if err := gtp5gnl.RemoveQEROID(g.client, g.link.link, p.OID); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: RemoveQER[%#x] failed: %v", p.QERID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: RemoveQER[%#x] failed", p.QERID)
 		}
 	}
 
 	for _, p := range plan.RemoveFARs {
 		if err := gtp5gnl.RemoveFAROID(g.client, g.link.link, p.OID); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: RemoveFAR[%#x] failed: %v", p.FARID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: RemoveFAR[%#x] failed", p.FARID)
 		}
 	}
 
 	for _, p := range plan.UpdateFARs {
 		if err := gtp5gnl.UpdateFAROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: UpdateFAR[%#x] failed: %v", p.FARID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: UpdateFAR[%#x] failed", p.FARID)
 		}
 
 		if p.ApplyAction != nil {
@@ -1796,14 +1860,16 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 
 	for _, p := range plan.UpdateQERs {
 		if err := gtp5gnl.UpdateQEROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: UpdateQER[%#x] failed: %v", p.QERID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: UpdateQER[%#x] failed", p.QERID)
 		}
 	}
 
 	for _, p := range plan.UpdateURRs {
 		rs, err := gtp5gnl.UpdateURROID(g.client, g.link.link, p.OID, p.Attrs)
 		if err != nil {
-			g.log.Errorf("ExecuteModificationPlan: UpdateURR[%#x] failed: %v", p.URRID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: UpdateURR[%#x] failed", p.URRID)
 		}
 		for _, r := range rs {
 			result.USAReports = append(result.USAReports, g.convertUSAReport(r))
@@ -1812,13 +1878,15 @@ func (g *Gtp5g) ExecuteModificationPlan(plan *ModificationPlan) (*ExecutionResul
 
 	for _, p := range plan.UpdateBARs {
 		if err := gtp5gnl.UpdateBAROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: UpdateBAR[%#x] failed: %v", p.BARID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: UpdateBAR[%#x] failed", p.BARID)
 		}
 	}
 
 	for _, p := range plan.UpdatePDRs {
 		if err := gtp5gnl.UpdatePDROID(g.client, g.link.link, p.OID, p.Attrs); err != nil {
-			g.log.Errorf("ExecuteModificationPlan: UpdatePDR[%#x] failed: %v", p.PDRID, err)
+			g.rollbackCreatedRules(plan, created)
+			return nil, errors.Wrapf(err, "ModificationPlan: UpdatePDR[%#x] failed", p.PDRID)
 		}
 	}
 

--- a/internal/pfcp/session.go
+++ b/internal/pfcp/session.go
@@ -421,11 +421,16 @@ func (s *PfcpServer) handleSessionModificationRequest(
 	}
 
 	// ========================================================================
-	// PHASE 2: Execution - Execute all operations via gtp5gnl (best-effort)
+	// PHASE 2: Execution - Execute all operations via gtp5gnl (fail-fast)
 	// ========================================================================
 	execResult, err1 := sess.rnode.driver.ExecuteModificationPlan(plan)
 	if err1 != nil {
-		s.log.Errorf("Execute Modification Plan err: %v", err1)
+		// The rules created by this plan have been rolled back, so the session
+		// state must not be updated: reject the request instead of reporting
+		// success for rules that were not installed.
+		sess.log.Errorf("Mod execution error: %v", err1)
+		s.sendSessModFailRsp(req, sess, addr, ie.CauseRuleCreationModificationFailure)
+		return
 	}
 
 	// ========================================================================

--- a/internal/pfcp/session.go
+++ b/internal/pfcp/session.go
@@ -421,13 +421,16 @@ func (s *PfcpServer) handleSessionModificationRequest(
 	}
 
 	// ========================================================================
-	// PHASE 2: Execution - Execute all operations via gtp5gnl (fail-fast)
+	// PHASE 2: Execution - Execute all operations via gtp5gnl
+	// Create operations are fail-fast: an error here means a rule creation
+	// failed and the rules created by this plan were rolled back. Remove/Update
+	// operations are best-effort and never surface an error.
 	// ========================================================================
 	execResult, err1 := sess.rnode.driver.ExecuteModificationPlan(plan)
 	if err1 != nil {
-		// The rules created by this plan have been rolled back, so the session
-		// state must not be updated: reject the request instead of reporting
-		// success for rules that were not installed.
+		// A Create operation failed and was rolled back, so the session state
+		// must not be updated: reject the request instead of reporting success
+		// for rules that were not installed.
 		sess.log.Errorf("Mod execution error: %v", err1)
 		s.sendSessModFailRsp(req, sess, addr, ie.CauseRuleCreationModificationFailure)
 		return


### PR DESCRIPTION
This pull request improves the reliability and correctness of session modification handling by introducing fail-fast semantics and rollback for rule creation. Now, if any Create operation fails during a session modification, all rules created by that plan are rolled back, and the request is rejected. Remove, Update, and Query operations remain best-effort, logging errors but continuing execution.

**Modification Plan Execution Behavior:**

* Changed the behavior of `ExecuteModificationPlan` so that Create operations are fail-fast: if any rule creation fails, all previously created rules in the current plan are rolled back, and an error is returned. Remove/Update/Query operations are still best-effort and do not trigger rollbacks. (`internal/forwarder/driver.go`, `internal/forwarder/gtp5g.go`)

**Rollback Implementation:**

* Added the `createdRules` type and `rollbackCreatedRules` function to track and remove rules created during a plan, ensuring that partial changes are not left behind if a failure occurs during creation. (`internal/forwarder/gtp5g.go`)

**Session Modification Error Handling:**

* Updated session modification handling so that if a Create operation fails and triggers a rollback, the session state is not updated and the failure is reported back to the requester. (`internal/pfcp/session.go`)